### PR TITLE
use npm-run-all parallel run to stop server

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+package-lock=false
+save-exact=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,17 +17,7 @@ install:
 test_script:
   - .\node_modules\.bin\cypress version
   - .\node_modules\.bin\cypress verify
-  # Start NPM process in the background
-  # so we can kill it later
-  - ps: Start-Process -NoNewWindow -PassThru npm start
-  # prints running processes
-  - ps: Get-Process
-  - .\node_modules\.bin\cypress run
-
-on_finish:
-  # NPM should be under "cmd" process name
-  - ps: Get-Process -Name cmd | Stop-Process
-  - ps: Get-Process
+  - npm run test-ci
 
 # Don't actually build.
 build: off

--- a/package.json
+++ b/package.json
@@ -5,11 +5,14 @@
   "main": "index.js",
   "scripts": {
     "start": "http-server app -c-1",
+    "start-ci": "http-server app -c-1 --silent",
     "dev": "npm start -- -o",
     "release": "releaser",
     "test": "npm start & cypress run",
     "pretest": "npm run lint",
-    "lint": "eslint --fix cypress/**/*.js"
+    "lint": "eslint --fix cypress/**/*.js",
+    "e2e": "cypress run",
+    "test-ci": "run-p --race start-ci e2e"
   },
   "repository": {
     "type": "git",
@@ -22,12 +25,13 @@
   },
   "homepage": "https://github.com/cypress-io/cypress-example-kitchensink#readme",
   "dependencies": {
-    "http-server": "^0.8.5"
+    "http-server": "0.10.0"
   },
   "devDependencies": {
     "@cypress/releaser": "0.2.1",
     "cypress": "1.0.1",
     "eslint": "^4.0.0",
+    "npm-run-all": "^4.1.1",
     "stop-build": "^1.1.0"
   }
 }


### PR DESCRIPTION
Avoid manually stopping process which breaks on Windows by using `npm-run-all` utility with `--race` flag

https://github.com/mysticatea/npm-run-all/blob/master/docs/run-p.md