### PR TITLE
add example test for have.all.keys

### DIFF
--- a/cypress/integration/example_spec.js
+++ b/cypress/integration/example_spec.js
@@ -681,6 +681,15 @@ describe('Kitchen Sink', function(){
     })
 
     describe('Explicit Assertions', function(){
+      // https://on.cypress.io/assertions
+      it('expect shape of an object', function(){
+        const person = {
+          name: 'Joe',
+          age: 20
+        }
+        expect(person).to.have.all.keys('name', 'age')
+      })
+
       it('expect - make an assertion about a specified subject', function(){
         // We can use Chai's BDD style assertions
         expect(true).to.be.true

--- a/cypress/integration/example_spec.js
+++ b/cypress/integration/example_spec.js
@@ -682,7 +682,7 @@ describe('Kitchen Sink', function(){
 
     describe('Explicit Assertions', function(){
       // https://on.cypress.io/assertions
-      it('expect shape of an object', function(){
+      it('expect - assert shape of an object', function(){
         const person = {
           name: 'Joe',
           age: 20

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "pretest": "npm run lint",
     "lint": "eslint --fix cypress/**/*.js",
     "e2e": "cypress run",
-    "test-ci": "run-p --race start-ci e2e"
+    "test-ci": "run-p --race start-ci e2e",
+    "cy:run": "cypress run",
+    "cy:open": "cypress open"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is example test that shows badly formatted text in the reporter.

```js
it('expect shape of an object', function(){
        const person = {
          name: 'Joe',
          age: 20
        }
        expect(person).to.have.all.keys('name', 'age')
      })
```

<img width="423" alt="screen shot 2017-10-17 at 11 23 00 am" src="https://user-images.githubusercontent.com/2212006/31673686-e024dd62-b32d-11e7-83bb-0aa77cd4d7bc.png">
