### PR TITLE
Revert "fix(deps): update dependency http-server to version 0.11.1 🌟"

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/cypress-io/cypress-example-kitchensink#readme",
   "dependencies": {
-    "http-server": "0.11.1",
+    "http-server": "0.10.0",
     "npm-run-all": "^4.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts cypress-io/cypress-example-kitchensink#77
Didn't update package-lock.json