### PR TITLE
more assertion examples

### DIFF
--- a/app/commands/assertions.html
+++ b/app/commands/assertions.html
@@ -206,7 +206,7 @@ assert.isObject(person, 'value is object')</code></pre>
         </div>
 
         <div class="col-xs-12">
-          <p>Assert that element's class starts with <code>heading-</code>.</p>
+          <p>Assert that element's class includes <code>heading-</code>.</p>
         </div>
 
         <div class="col-xs-7">
@@ -216,7 +216,7 @@ assert.isObject(person, 'value is object')</code></pre>
     expect($div).to.have.length(1)
 
     const className = $div[0].className
-    
+
     expect(className).to.match(/heading-/)
   })
   // .then(cb) callback is not retried,
@@ -247,9 +247,9 @@ assert.isObject(person, 'value is object')</code></pre>
     }
 
     const className = $div[0].className
-    
+
     if (!className.match(/heading-/)) {
-      throw new Error(`Could not find class starting with "heading-" in ${className}`)
+      throw new Error(`Could not find class "heading-" in ${className}`)
     }
   })</code></pre>
         </div>

--- a/app/commands/assertions.html
+++ b/app/commands/assertions.html
@@ -142,11 +142,29 @@
         </div>
 
         <div class="col-xs-7">
-          <pre><code class="javascript">// We can use Chai's BDD style assertions
-expect(true).to.be.true
+          <pre><code class="javascript">expect(true).to.be.true
 const o = { foo: 'bar' }
 expect(o).to.equal(o)
 expect(o).to.deep.equal({ foo: 'bar' })</code></pre>
+        </div>
+
+        <div class="col-xs-12"><hr></div>
+
+        <div class="col-xs-7">
+          <h4>assert</h4>
+          <p>To make a TDD assertion about a specified subject, use <a href="https://on.cypress.io/assertions"><code>assert</code></a>.</p>
+          <pre><code class="javascript">const person = {
+  name: 'Joe',
+  age: 20,
+}
+assert.isObject(person, 'value is object')</code></pre>
+        </div>
+
+        <div class="col-xs-12"><hr></div>
+
+        <div class="col-xs-12">
+          <h3>Should with callback function</h3>
+          <hr>
         </div>
 
         <div class="col-xs-12">
@@ -215,8 +233,11 @@ expect(o).to.deep.equal({ foo: 'bar' })</code></pre>
           </div>
         </div>
 
-        <div class="col-xs-7">
+        <div class="col-xs-12">
           <p>You can throw any error from the callback function. The callback will be retried, but the assertions will not be shown as nicely in the Command Log UI as Chai assertions.</p>
+        </div>
+
+        <div class="col-xs-7">
           <pre><code class="javascript">cy.get('.scope-classes').find('div')
   .should(($div) => {
     if ($div.length !== 1) {
@@ -229,18 +250,6 @@ expect(o).to.deep.equal({ foo: 'bar' })</code></pre>
       throw new Error(`Could not find class starting with "heading-" in ${className}`)
     }
   })</code></pre>
-        </div>
-
-        <div class="col-xs-12"><hr></div>
-
-        <div class="col-xs-12">
-          <h4>assert</h4>
-          <p>To make a TDD assertion about a specified subject, use <a href="https://on.cypress.io/assertions"><code>assert</code></a>.</p>
-          <pre><code class="javascript">const person = {
-  name: 'Joe',
-  age: 20,
-}
-assert.isObject(person, 'value is object')</code></pre>
         </div>
 
         <div class="col-xs-12"><hr></div>

--- a/app/commands/assertions.html
+++ b/app/commands/assertions.html
@@ -136,15 +136,27 @@
           <hr>
         </div>
 
-        <div class="col-xs-7">
+        <div class="col-xs-12">
           <h4>expect</h4>
           <p>To make a BDD assertion about a specified subject, use <a href="https://on.cypress.io/assertions"><code>expect</code></a>.</p>
+        </div>
+
+        <div class="col-xs-7">
           <pre><code class="javascript">// We can use Chai's BDD style assertions
 expect(true).to.be.true
+const o = { foo: 'bar' }
+expect(o).to.equal(o)
+expect(o).to.deep.equal({ foo: 'bar' })</code></pre>
+        </div>
 
-// Pass a function to should that can have any number
-// of explicit assertions within it.
-cy.get('.assertions-p').find('p')
+        <div class="col-xs-12">
+          <p>You can write your own complicated checks using <code>.should(cb)</code> function if included assertions are not enough.
+            Pass a function to <code>should()</code> with any number of explicit assertions within it.
+            The callback function will be retried until it passes all your explicit assertions or times out.</p>
+        </div>
+
+        <div class="col-xs-7">
+          <pre><code class="javascript">cy.get('.assertions-p').find('p')
 .should(($p) => {
   // return an array of texts from all of the p's
   let texts = $p.map((i, el) => // https://on.cypress.io/$
@@ -171,6 +183,34 @@ cy.get('.assertions-p').find('p')
               <p>Some text from first p</p>
               <p>More text from second p</p>
               <p>And even more text from third p</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-xs-12">
+          <p>Asserting that an element has class that starts with <code>heading-</code>.</p>
+        </div>
+
+        <div class="col-xs-7">
+          <pre><code class="javascript">cy.get('.scope-classes').find('div')
+// .should(cb) callback function will be retried
+.should(($div) => {
+  expect($div).to.have.length(1)
+
+  const classes = $div[0].className
+  expect(classes).to.match(/heading-/)
+})
+// .then(cb) callback is not retried,
+// it either passes or fails
+.then(($div) => {
+  expect($div).to.have.text('Scoped classes')
+})</code></pre>
+        </div>
+
+        <div class="col-xs-5">
+          <div class="well">
+            <div class='scope-classes'>
+              <div class="main-abc123 heading-xyz987">Scoped classes</div>
             </div>
           </div>
         </div>

--- a/app/commands/assertions.html
+++ b/app/commands/assertions.html
@@ -157,25 +157,25 @@ expect(o).to.deep.equal({ foo: 'bar' })</code></pre>
 
         <div class="col-xs-7">
           <pre><code class="javascript">cy.get('.assertions-p').find('p')
-.should(($p) => {
-  // return an array of texts from all of the p's
-  let texts = $p.map((i, el) => // https://on.cypress.io/$
-    Cypress.$(el).text())
+  .should(($p) => {
+    // return an array of texts from all of the p's
+    let texts = $p.map((i, el) => // https://on.cypress.io/$
+      Cypress.$(el).text())
 
-  // jquery map returns jquery object
-  // and .get() convert this to simple array
-  texts = texts.get()
+    // jquery map returns jquery object
+    // and .get() convert this to simple array
+    texts = texts.get()
 
-  // array should have length of 3
-  expect(texts).to.have.length(3)
+    // array should have length of 3
+    expect(texts).to.have.length(3)
 
-  // set this specific subject
-  expect(texts).to.deep.eq([
-    'Some text from first p',
-    'More text from second p',
-    'And even more text from third p',
-  ])
-})</code></pre>
+    // set this specific subject
+    expect(texts).to.deep.eq([
+      'Some text from first p',
+      'More text from second p',
+      'And even more text from third p',
+    ])
+  })</code></pre>
         </div>
         <div class="col-xs-5">
           <div class="well">
@@ -193,18 +193,18 @@ expect(o).to.deep.equal({ foo: 'bar' })</code></pre>
 
         <div class="col-xs-7">
           <pre><code class="javascript">cy.get('.scope-classes').find('div')
-// .should(cb) callback function will be retried
-.should(($div) => {
-  expect($div).to.have.length(1)
+  // .should(cb) callback function will be retried
+  .should(($div) => {
+    expect($div).to.have.length(1)
 
-  const className = $div[0].className
-  expect(className).to.match(/heading-/)
-})
-// .then(cb) callback is not retried,
-// it either passes or fails
-.then(($div) => {
-  expect($div).to.have.text('Scoped classes')
-})</code></pre>
+    const className = $div[0].className
+    expect(className).to.match(/heading-/)
+  })
+  // .then(cb) callback is not retried,
+  // it either passes or fails
+  .then(($div) => {
+    expect($div).to.have.text('Scoped classes')
+  })</code></pre>
         </div>
 
         <div class="col-xs-5">
@@ -213,6 +213,22 @@ expect(o).to.deep.equal({ foo: 'bar' })</code></pre>
               <div class="main-abc123 heading-xyz987">Scoped classes</div>
             </div>
           </div>
+        </div>
+
+        <div class="col-xs-7">
+          <p>You can throw any error from the callback function. The callback will be retried, but the assertions will not be shown as nicely in the Command Log UI as Chai assertions.</p>
+          <pre><code class="javascript">cy.get('.scope-classes').find('div')
+  .should(($div) => {
+    if ($div.length !== 1) {
+      // you can throw your own errors
+      throw new Error('Did not find 1 element')
+    }
+
+    const className = $div[0].className
+    if (!className.match(/heading-/)) {
+      throw new Error(`Could not find class starting with "heading-" in ${className}`)
+    }
+  })</code></pre>
         </div>
 
         <div class="col-xs-12"><hr></div>

--- a/app/commands/assertions.html
+++ b/app/commands/assertions.html
@@ -206,29 +206,30 @@ assert.isObject(person, 'value is object')</code></pre>
         </div>
 
         <div class="col-xs-12">
-          <p>Asserting that an element has class that starts with <code>heading-</code>.</p>
+          <p>Assert that element's class starts with <code>heading-</code>.</p>
         </div>
 
         <div class="col-xs-7">
-          <pre><code class="javascript">cy.get('.scope-classes').find('div')
+          <pre><code class="javascript">cy.get('.docs-header').find('div')
   // .should(cb) callback function will be retried
   .should(($div) => {
     expect($div).to.have.length(1)
 
     const className = $div[0].className
+    
     expect(className).to.match(/heading-/)
   })
   // .then(cb) callback is not retried,
   // it either passes or fails
   .then(($div) => {
-    expect($div).to.have.text('Scoped classes')
+    expect($div).to.have.text('Introduction')
   })</code></pre>
         </div>
 
         <div class="col-xs-5">
           <div class="well">
-            <div class="scope-classes">
-              <div class="main-abc123 heading-xyz987">Scoped classes</div>
+            <div class="docs-header">
+              <div class="main-abc123 heading-xyz987">Introduction</div>
             </div>
           </div>
         </div>
@@ -238,7 +239,7 @@ assert.isObject(person, 'value is object')</code></pre>
         </div>
 
         <div class="col-xs-7">
-          <pre><code class="javascript">cy.get('.scope-classes').find('div')
+          <pre><code class="javascript">cy.get('.docs-header').find('div')
   .should(($div) => {
     if ($div.length !== 1) {
       // you can throw your own errors
@@ -246,6 +247,7 @@ assert.isObject(person, 'value is object')</code></pre>
     }
 
     const className = $div[0].className
+    
     if (!className.match(/heading-/)) {
       throw new Error(`Could not find class starting with "heading-" in ${className}`)
     }

--- a/app/commands/assertions.html
+++ b/app/commands/assertions.html
@@ -197,8 +197,8 @@ expect(o).to.deep.equal({ foo: 'bar' })</code></pre>
 .should(($div) => {
   expect($div).to.have.length(1)
 
-  const classes = $div[0].className
-  expect(classes).to.match(/heading-/)
+  const className = $div[0].className
+  expect(className).to.match(/heading-/)
 })
 // .then(cb) callback is not retried,
 // it either passes or fails
@@ -209,7 +209,7 @@ expect(o).to.deep.equal({ foo: 'bar' })</code></pre>
 
         <div class="col-xs-5">
           <div class="well">
-            <div class='scope-classes'>
+            <div class="scope-classes">
               <div class="main-abc123 heading-xyz987">Scoped classes</div>
             </div>
           </div>

--- a/cypress/integration/examples/assertions.spec.js
+++ b/cypress/integration/examples/assertions.spec.js
@@ -67,7 +67,7 @@ context('Assertions', () => {
           expect($div).to.have.length(1)
 
           const className = $div[0].className
-          
+
           expect(className).to.match(/heading-/)
         })
         // .then(cb) callback is not retried,
@@ -86,9 +86,9 @@ context('Assertions', () => {
           }
 
           const className = $div[0].className
-          
+
           if (!className.match(/heading-/)) {
-            throw new Error(`Could not find class starting with "heading-" in ${className}`)
+            throw new Error(`Could not find class "heading-" in ${className}`)
           }
         })
     })

--- a/cypress/integration/examples/assertions.spec.js
+++ b/cypress/integration/examples/assertions.spec.js
@@ -66,8 +66,8 @@ context('Assertions', () => {
         .should(($div) => {
           expect($div).to.have.length(1)
 
-          const classes = $div[0].className
-          expect(classes).to.match(/heading-/)
+          const className = $div[0].className
+          expect(className).to.match(/heading-/)
         })
         // .then(cb) callback is not retried,
         // it either passes or fails

--- a/cypress/integration/examples/assertions.spec.js
+++ b/cypress/integration/examples/assertions.spec.js
@@ -27,9 +27,16 @@ context('Assertions', () => {
     it('expect - make an assertion about a specified subject', () => {
       // We can use Chai's BDD style assertions
       expect(true).to.be.true
+      const o = { foo: 'bar' }
+      expect(o).to.equal(o)
+      expect(o).to.deep.equal({ foo: 'bar' })
+    })
 
+    it('pass your own callback function to should()', () => {
       // Pass a function to should that can have any number
       // of explicit assertions within it.
+      // The ".should(cb)" function will be retried
+      // automatically until it passes all your explicit assertions or times out.
       cy.get('.assertions-p').find('p')
       .should(($p) => {
         // return an array of texts from all of the p's
@@ -51,6 +58,22 @@ context('Assertions', () => {
           'And even more text from third p',
         ])
       })
+    })
+
+    it('finds element by class name regex', () => {
+      cy.get('.scope-classes').find('div')
+        // .should(cb) callback function will be retried
+        .should(($div) => {
+          expect($div).to.have.length(1)
+
+          const classes = $div[0].className
+          expect(classes).to.match(/heading-/)
+        })
+        // .then(cb) callback is not retried,
+        // it either passes or fails
+        .then(($div) => {
+          expect($div).to.have.text('Scoped classes')
+        })
     })
 
     it('assert - assert shape of an object', () => {

--- a/cypress/integration/examples/assertions.spec.js
+++ b/cypress/integration/examples/assertions.spec.js
@@ -61,23 +61,24 @@ context('Assertions', () => {
     })
 
     it('finds element by class name regex', () => {
-      cy.get('.scope-classes').find('div')
+      cy.get('.docs-header').find('div')
         // .should(cb) callback function will be retried
         .should(($div) => {
           expect($div).to.have.length(1)
 
           const className = $div[0].className
+          
           expect(className).to.match(/heading-/)
         })
         // .then(cb) callback is not retried,
         // it either passes or fails
         .then(($div) => {
-          expect($div).to.have.text('Scoped classes')
+          expect($div).to.have.text('Introduction')
         })
     })
 
     it('can throw any error', () => {
-      cy.get('.scope-classes').find('div')
+      cy.get('.docs-header').find('div')
         .should(($div) => {
           if ($div.length !== 1) {
             // you can throw your own errors
@@ -85,6 +86,7 @@ context('Assertions', () => {
           }
 
           const className = $div[0].className
+          
           if (!className.match(/heading-/)) {
             throw new Error(`Could not find class starting with "heading-" in ${className}`)
           }

--- a/cypress/integration/examples/assertions.spec.js
+++ b/cypress/integration/examples/assertions.spec.js
@@ -76,6 +76,21 @@ context('Assertions', () => {
         })
     })
 
+    it('can throw any error', () => {
+      cy.get('.scope-classes').find('div')
+        .should(($div) => {
+          if ($div.length !== 1) {
+            // you can throw your own errors
+            throw new Error('Did not find 1 element')
+          }
+
+          const className = $div[0].className
+          if (!className.match(/heading-/)) {
+            throw new Error(`Could not find class starting with "heading-" in ${className}`)
+          }
+        })
+    })
+
     it('assert - assert shape of an object', () => {
       const person = {
         name: 'Joe',


### PR DESCRIPTION
- closes #164 for https://github.com/cypress-io/cypress-documentation/issues/1267

`.should(cb)` needs more examples because that is the one assertion people should be writing when our built-in assertions are not enough

![screen shot 2018-12-29 at 10 40 24 am](https://user-images.githubusercontent.com/2212006/50539915-5274f380-0b56-11e9-948a-041819a310ce.png)
