### PR TITLE
chore: updated gitlab template using extends key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1850,9 +1850,9 @@
       "dev": true
     },
     "eslint-plugin-mocha": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-5.2.1.tgz",
-      "integrity": "sha512-v95cxwpPiyt2Gb/Moog8KQtaT+KlGGMbqpOkcP/eIkvaovPEcTprOYywAOo1On+KDsfEbJ4mByfcfUEwrxH9Gw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-5.3.0.tgz",
+      "integrity": "sha512-3uwlJVLijjEmBeNyH60nzqgA1gacUWLUmcKV8PIGNvj1kwP/CTgAWQHn2ayyJVwziX+KETkr9opNwT1qD/RZ5A==",
       "dev": true,
       "requires": {
         "ramda": "^0.26.1"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "eslint": "5.13.0",
     "eslint-plugin-cypress": "2.2.0",
     "eslint-plugin-cypress-dev": "2.0.0",
-    "eslint-plugin-mocha": "5.2.1",
+    "eslint-plugin-mocha": "5.3.0",
     "globby": "9.0.0",
     "husky": "1.3.1",
     "semantic-release": "15.13.3",


### PR DESCRIPTION
Gitlab added `extends` job key, which is easier to understand and read then YAML anchors.

https://docs.gitlab.com/ee/ci/yaml/#extends