### PR TITLE
fix typo in scaffolded command.js

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -21,5 +21,5 @@
 // Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
 //
 //
-// -- This is will overwrite an existing command --
+// -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })


### PR DESCRIPTION
Minor typo fix for the scaffolded command.js.

Related to: https://github.com/cypress-io/cypress/pull/3677