### PR TITLE
chore: add another Moment example

### DIFF
--- a/app/utilities.html
+++ b/app/utilities.html
@@ -151,10 +151,26 @@ cy.wrap($li)
         <div class="col-xs-7">
           <h4><a href="https://on.cypress.io/moment">Cypress.moment()</a></h4>
           <p>To parse or format a date using a moment method, use the <a href="https://on.cypress.io/moment"><code>Cypress.moment()</code></a> command.</p>
-          <pre><code class="javascript">let time = Cypress.moment().utc('2014-04-25T19:38:53.196Z').format('h:mm A')
+          <pre><code class="javascript">const time = Cypress.moment().utc('2014-04-25T19:38:53.196Z').format('h:mm A')
 
 cy.get('.utility-moment').contains('3:38 PM')
-  .should('have.class', 'badge')</code></pre>
+  .should('have.class', 'badge')
+
+// the time in the element should be between 3pm and 5pm
+const start = Cypress.moment('3:00 PM', 'LT')
+const end = Cypress.moment('5:00 PM', 'LT')
+
+cy.get('.utility-moment .badge')
+  .should(($el) => {
+    // parse American time like "3:38 PM"
+    const m = Cypress.moment($el.text().trim(), 'LT')
+
+    // display hours + minutes + AM|PM
+    const f = 'h:mm A'
+
+    expect(m.isBetween(start, end),
+      `${m.format(f)} should be between ${start.format(f)} and ${end.format(f)}`).to.be.true
+  })</code></pre>
         </div>
         <div class="col-xs-5">
           <div class="well">

--- a/cypress/integration/examples/utilities.spec.js
+++ b/cypress/integration/examples/utilities.spec.js
@@ -75,13 +75,28 @@ context('Utilities', () => {
 
   it('Cypress.moment() - format or parse dates using a moment method', () => {
     // https://on.cypress.io/moment
-    // eslint-disable-next-line no-unused-vars
     const time = Cypress.moment().utc('2014-04-25T19:38:53.196Z').format('h:mm A')
 
     expect(time).to.be.a('string')
 
     cy.get('.utility-moment').contains('3:38 PM')
       .should('have.class', 'badge')
+
+    // the time in the element should be between 3pm and 5pm
+    const start = Cypress.moment('3:00 PM', 'LT')
+    const end = Cypress.moment('5:00 PM', 'LT')
+
+    cy.get('.utility-moment .badge')
+      .should(($el) => {
+        // parse American time like "3:38 PM"
+        const m = Cypress.moment($el.text().trim(), 'LT')
+
+        // display hours + minutes + AM|PM
+        const f = 'h:mm A'
+
+        expect(m.isBetween(start, end),
+          `${m.format(f)} should be between ${start.format(f)} and ${end.format(f)}`).to.be.true
+      })
   })
 
 


### PR DESCRIPTION
Prompted by the stackoverflow and gitter question

https://stackoverflow.com/questions/55272549/compare-datetime-function-cypress

<img width="906" alt="Screen Shot 2019-03-20 at 10 07 21 PM" src="https://user-images.githubusercontent.com/2212006/54729959-99bebf00-4b5c-11e9-9120-1c46b65407c7.png">

<img width="1277" alt="Screen Shot 2019-03-20 at 10 10 34 PM" src="https://user-images.githubusercontent.com/2212006/54730049-0cc83580-4b5d-11e9-9b02-87d809b123f5.png">
