### PR TITLE
Upgrade libnss3 library on Shippable CI to support Cypress v3.3.0

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -30,7 +30,8 @@ build:
     - /root/.cache
   ci:
     # update libnss3 library first for Cypress v3.3.0
-    - sudo apt-get install --reinstall libnss3
+    - sudo apt-get update --yes
+    - sudo apt-get install --yes --reinstall libnss3
     - locale -a
     - npm ci
     # prints all environment variables that start with SHIPPABLE

--- a/shippable.yml
+++ b/shippable.yml
@@ -29,6 +29,7 @@ build:
     image_name: cypress/base
     image_tag: 10
     pull: true
+
   # Caching configuration to avoid reinstalling node modules and Cypress binary again and again
   # http://docs.shippable.com/ci/caching/
   cache: true
@@ -36,6 +37,14 @@ build:
     - /root/.npm
     - /root/.cache
   ci:
+    # fixing cy.exec problem
+    # setlocale: LC_ALL: cannot change locale (en_US.UTF-8)' to be empty
+    # https://github.com/tianon/docker-brew-debian/issues/45
+    - echo "LC_ALL=en_US.UTF-8" >> /etc/environment
+    - echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+    - echo "LANG=en_US.UTF-8" > /etc/locale.conf
+    - locale-gen en_US.UTF-8
+
     - npm ci
     # prints all environment variables that start with SHIPPABLE
     # useful to configure parallel builds for example

--- a/shippable.yml
+++ b/shippable.yml
@@ -21,16 +21,6 @@ env:
   # http://docs.shippable.com/ci/env-vars/
   - secure: NYNAyBbsaXNbM6X+ZUB6Wer2iq0cze1jk972yqfTkLUoQd4RRP7uUdGtT9gywZEQC7WmyKGL+GzoZ05kgTzJ95IRkWnHRzBVmr1oFgANaaQD7/1wXVwb40XixywyqyX7LqW7cu14CyHA0BK0mjM0eWINisn1h+LkQsIHBRcxUdS29p3Hb7h7jX0TSqM4ylPnH583xrjr53ILcrctpmudp5NZ8cCIsLIrhTv04QkiQDqtgWzkK1iHBvFvWF98GMP6dBfAxyY2Q5Qb1GewaTm4GkZkJPzcuxUd98+d3y1gOP97VmNczA+yk3KLF9bCvDlAo0nItpoj9zrilvjqvisDgw==
 
-
-build:
-  # custom docker image documentation
-  # http://docs.shippable.com/ci/custom-docker-image/
-  pre_ci_boot:
-    image_name: cypress/base
-    image_tag: 10
-    pull: true
-    env: LC_ALL=
-
   # Caching configuration to avoid reinstalling node modules and Cypress binary again and again
   # http://docs.shippable.com/ci/caching/
   cache: true
@@ -38,6 +28,8 @@ build:
     - /root/.npm
     - /root/.cache
   ci:
+    # update libnss3 library first for Cypress v3.3.0
+    - sudo apt-get install --reinstall libnss3
     - locale -a
     - npm ci
     # prints all environment variables that start with SHIPPABLE

--- a/shippable.yml
+++ b/shippable.yml
@@ -27,9 +27,8 @@ build:
   # http://docs.shippable.com/ci/custom-docker-image/
   pre_ci_boot:
     image_name: cypress/base
-    image_tag: 12.1.0
+    image_tag: 10
     pull: true
-    env: LANG=en_US.UTF-8
   # Caching configuration to avoid reinstalling node modules and Cypress binary again and again
   # http://docs.shippable.com/ci/caching/
   cache: true

--- a/shippable.yml
+++ b/shippable.yml
@@ -23,6 +23,12 @@ env:
 
 
 build:
+  # custom docker image documentation
+  # http://docs.shippable.com/ci/custom-docker-image/
+  pre_ci_boot:
+    image_name: cypress/base
+    image_tag: 12
+    pull: true
   # Caching configuration to avoid reinstalling node modules and Cypress binary again and again
   # http://docs.shippable.com/ci/caching/
   cache: true

--- a/shippable.yml
+++ b/shippable.yml
@@ -32,7 +32,6 @@ build:
     # update libnss3 library first for Cypress v3.3.0
     - sudo apt-get update --yes
     - sudo apt-get install --yes --reinstall libnss3
-    - locale -a
     - npm ci
     # prints all environment variables that start with SHIPPABLE
     # useful to configure parallel builds for example

--- a/shippable.yml
+++ b/shippable.yml
@@ -29,6 +29,7 @@ build:
     image_name: cypress/base
     image_tag: 12.1.0
     pull: true
+    env: LANG=en_US.UTF-8
   # Caching configuration to avoid reinstalling node modules and Cypress binary again and again
   # http://docs.shippable.com/ci/caching/
   cache: true

--- a/shippable.yml
+++ b/shippable.yml
@@ -21,7 +21,7 @@ env:
   # http://docs.shippable.com/ci/env-vars/
   - secure: NYNAyBbsaXNbM6X+ZUB6Wer2iq0cze1jk972yqfTkLUoQd4RRP7uUdGtT9gywZEQC7WmyKGL+GzoZ05kgTzJ95IRkWnHRzBVmr1oFgANaaQD7/1wXVwb40XixywyqyX7LqW7cu14CyHA0BK0mjM0eWINisn1h+LkQsIHBRcxUdS29p3Hb7h7jX0TSqM4ylPnH583xrjr53ILcrctpmudp5NZ8cCIsLIrhTv04QkiQDqtgWzkK1iHBvFvWF98GMP6dBfAxyY2Q5Qb1GewaTm4GkZkJPzcuxUd98+d3y1gOP97VmNczA+yk3KLF9bCvDlAo0nItpoj9zrilvjqvisDgw==
 
-- build:
+build:
   # Caching configuration to avoid reinstalling node modules and Cypress binary again and again
   # http://docs.shippable.com/ci/caching/
   cache: true

--- a/shippable.yml
+++ b/shippable.yml
@@ -21,6 +21,7 @@ env:
   # http://docs.shippable.com/ci/env-vars/
   - secure: NYNAyBbsaXNbM6X+ZUB6Wer2iq0cze1jk972yqfTkLUoQd4RRP7uUdGtT9gywZEQC7WmyKGL+GzoZ05kgTzJ95IRkWnHRzBVmr1oFgANaaQD7/1wXVwb40XixywyqyX7LqW7cu14CyHA0BK0mjM0eWINisn1h+LkQsIHBRcxUdS29p3Hb7h7jX0TSqM4ylPnH583xrjr53ILcrctpmudp5NZ8cCIsLIrhTv04QkiQDqtgWzkK1iHBvFvWF98GMP6dBfAxyY2Q5Qb1GewaTm4GkZkJPzcuxUd98+d3y1gOP97VmNczA+yk3KLF9bCvDlAo0nItpoj9zrilvjqvisDgw==
 
+- build:
   # Caching configuration to avoid reinstalling node modules and Cypress binary again and again
   # http://docs.shippable.com/ci/caching/
   cache: true

--- a/shippable.yml
+++ b/shippable.yml
@@ -27,7 +27,7 @@ build:
   # http://docs.shippable.com/ci/custom-docker-image/
   pre_ci_boot:
     image_name: cypress/base
-    image_tag: 12
+    image_tag: 12.1.0
     pull: true
   # Caching configuration to avoid reinstalling node modules and Cypress binary again and again
   # http://docs.shippable.com/ci/caching/

--- a/shippable.yml
+++ b/shippable.yml
@@ -38,6 +38,7 @@ build:
     - /root/.npm
     - /root/.cache
   ci:
+    - locale -a
     - npm ci
     # prints all environment variables that start with SHIPPABLE
     # useful to configure parallel builds for example

--- a/shippable.yml
+++ b/shippable.yml
@@ -29,6 +29,7 @@ build:
     image_name: cypress/base
     image_tag: 10
     pull: true
+    env: LC_ALL=
 
   # Caching configuration to avoid reinstalling node modules and Cypress binary again and again
   # http://docs.shippable.com/ci/caching/
@@ -37,14 +38,6 @@ build:
     - /root/.npm
     - /root/.cache
   ci:
-    # fixing cy.exec problem
-    # setlocale: LC_ALL: cannot change locale (en_US.UTF-8)' to be empty
-    # https://github.com/tianon/docker-brew-debian/issues/45
-    - echo "LC_ALL=en_US.UTF-8" >> /etc/environment
-    - echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
-    - echo "LANG=en_US.UTF-8" > /etc/locale.conf
-    - locale-gen en_US.UTF-8
-
     - npm ci
     # prints all environment variables that start with SHIPPABLE
     # useful to configure parallel builds for example


### PR DESCRIPTION
- closes #251 

Trying to fix display crashing on Shippable by using our Docker image.
Hitting a problem
```
'/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)' to be empty
```
inside `cy.exec` test https://app.shippable.com/github/cypress-io/cypress-example-kitchensink/runs/753/1/console