### PR TITLE
Update Semaphore v2 example

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,6 +1,8 @@
 # copied from https://docs.semaphoreci.com/article/50-pipeline-yaml
 # NodeJS and JavaScript docs
 # https://docs.semaphoreci.com/article/82-language-javascript-and-nodejs
+
+# Semaphore v2 API starts with version 1.0 :)
 version: v1.0
 name: Cypress example Kitchensink
 
@@ -48,14 +50,8 @@ blocks:
   - name: Linux E2E tests
     task:
       agent:
-        # Linux machine with our Docker image
         machine:
           type: e1-standard-2
-        containers:
-          # use Cypress-provided Docker image
-          # https://github.com/cypress-io/cypress-docker-images
-          - name: main
-            image: 'cypress/browsers:node12.0.0-chrome75'
 
       # see https://docs.semaphoreci.com/article/66-environment-variables-and-secrets
       secrets:
@@ -66,6 +62,8 @@ blocks:
       # common commands that should be done before each E2E test command
       prologue:
         commands:
+          - nvm install 12
+          - npm install -g npm
           - checkout
 
           # from "How to Cache Cypress binary on Semaphore" documentation page

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -69,14 +69,14 @@ blocks:
           # restore previously cached files if any
           # re-install dependencies if package.json or this semaphore YML file changes
           - cache restore npm-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json)-$(checksum .semaphore/semaphore.yml)
-          - cache restore cypress-$SEMAPHORE_GIT_BRANCH-$(checksum .semaphore/semaphore.yml)
+          - cache restore cypress-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json)-$(checksum .semaphore/semaphore.yml)
 
           - npm ci
           # verify the Cypress test binary so its check status is cached
           - npm run cy:verify
           # Cache NPM dependencies and Cypress binary
           - cache store npm-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json)-$(checksum .semaphore/semaphore.yml) ~/.npm
-          - cache store cypress-$SEMAPHORE_GIT_BRANCH-$(checksum .semaphore/semaphore.yml) ~/.cache/Cypress
+          - cache store cypress-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json)-$(checksum .semaphore/semaphore.yml) ~/.cache/Cypress
 
           # prints SEMAPHORE_* environment variables
           - npm run print-env -- SEMAPHORE
@@ -89,20 +89,14 @@ blocks:
         # all "prologue" commands have finished by now
         # and we can define several jobs to execute in parallel on 3 machines
         # for Cypress https://on.cypress.io/parallelization
-        # Cypress v3.4.0 recognizes Semaphore environment variables
+        # Cypress recognizes Semaphore environment variables
         # in order to link these separate steps into a single run.
         - name: Cypress E2E 1
           commands:
-            # prints SEMAPHORE_* environment variables
-            - npm run print-env -- SEMAPHORE
-            - npx cypress run --record --parallel --group "Semaphore 3x" --ci-build-id $SEMAPHORE_PIPELINE_ID
+            - npx cypress run --record --parallel --group "Semaphore 3x"
         - name: Cypress E2E 2
           commands:
-            # prints SEMAPHORE_* environment variables
-            - npm run print-env -- SEMAPHORE
-            - npx cypress run --record --parallel --group "Semaphore 3x" --ci-build-id $SEMAPHORE_PIPELINE_ID
+            - npx cypress run --record --parallel --group "Semaphore 3x"
         - name: Cypress E2E 3
           commands:
-            # prints SEMAPHORE_* environment variables
-            - npm run print-env -- SEMAPHORE
-            - npx cypress run --record --parallel --group "Semaphore 3x" --ci-build-id $SEMAPHORE_PIPELINE_ID
+            - npx cypress run --record --parallel --group "Semaphore 3x"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -66,19 +66,17 @@ blocks:
           - npm install -g npm
           - checkout
 
-          # from "How to Cache Cypress binary on Semaphore" documentation page
-          # https://semaphoreci.com/docs/caching-between-builds.html#caching-cypress-binary
-          - mkdir -p $SEMAPHORE_CACHE_DIR/Cypress
-          - mkdir -p ~/.cache || true
-          - ln -s $SEMAPHORE_CACHE_DIR/Cypress ~/.cache/Cypress
-
           # restore previously cached files if any
           # re-install dependencies if package.json or this semaphore YML file changes
           - cache restore npm-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json)-$(checksum .semaphore/semaphore.yml)
+          - cache restore cypress-$SEMAPHORE_GIT_BRANCH-$(checksum .semaphore/semaphore.yml)
+
           - npm ci
           # verify the Cypress test binary so its check status is cached
           - npm run cy:verify
+          # Cache NPM dependencies and Cypress binary
           - cache store npm-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json)-$(checksum .semaphore/semaphore.yml) ~/.npm
+          - cache store cypress-$SEMAPHORE_GIT_BRANCH-$(checksum .semaphore/semaphore.yml) ~/.cache/Cypress
 
           # prints SEMAPHORE_* environment variables
           - npm run print-env -- SEMAPHORE

--- a/basic/.semaphore.yml
+++ b/basic/.semaphore.yml
@@ -7,12 +7,6 @@ agent:
   machine:
     type: e1-standard-2
 
-  containers:
-    # use Cypress-provided Docker image
-    # https://github.com/cypress-io/cypress-docker-images
-    - name: main
-      image: 'cypress/browsers:node12.0.0-chrome75'
-
 blocks:
   # installs NPM dependencies, builds the web application and
   # runs Cypress tests on a single machine
@@ -26,21 +20,22 @@ blocks:
       jobs:
         - name: npm ci and cache
           commands:
+            - nvm install 12
+            - npm install -g npm
             - checkout
-
-            # from "How to Cache Cypress binary on Semaphore" documentation page
-            # https://semaphoreci.com/docs/caching-between-builds.html#caching-cypress-binary
-            - mkdir -p $SEMAPHORE_CACHE_DIR/Cypress
-            - mkdir -p ~/.cache || true
-            - ln -s $SEMAPHORE_CACHE_DIR/Cypress ~/.cache/Cypress
 
             # restore previously cached files if any
             # re-install dependencies if package.json or this semaphore YML file changes
-            - cache restore npm-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json)-$(checksum .semaphore/semaphore.yml)
+            - cache restore npm-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json)-$(checksum basic/semaphore.yml)
+            - cache restore cypress-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json)-$(checksum basic/semaphore.yml)
+
             - npm ci
             # verify the Cypress test binary so its check status is cached
             - npm run cy:verify
-            - cache store npm-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json)-$(checksum .semaphore/semaphore.yml) ~/.npm
+
+            # cache NPM dependencies and Cypress binary
+            - cache store npm-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json)-$(checksum basic/semaphore.yml) ~/.npm
+            - cache store cypress-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json)-$(checksum basic/semaphore.yml) ~/.cache/Cypress
 
             # prints SEMAPHORE_* environment variables
             - npm run print-env -- SEMAPHORE


### PR DESCRIPTION
- removed Docker image, using standard Linux container
- simpler caching
- removed unnecessary custom build id, since Cypress understands Semaphore env variables
- updated basic example
- inspired by #288 