### PR TITLE
Use Cypress GitHub action

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           npm i -g @bahmutov/print-env
           print-env GITHUB
+          print-env BUILD
 
       # Restore the previous NPM modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -27,6 +27,22 @@ jobs:
           print-env BUILD
           cat $GITHUB_EVENT_PATH
 
+      # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#contexts
+      - name: Print job object
+        run: echo ${{ job }}
+
+      - name: Print steps object
+        run: echo ${{ steps }}
+
+      - name: Print runner object
+        run: echo ${{ runner }}
+
+      - name: Print strategy object
+        run: echo ${{ strategy }}
+
+      - name: Print matrix object
+        run: echo ${{ matrix }}
+
       # Restore the previous NPM modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire
       # workflow successfully finishes.

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -25,6 +25,7 @@ jobs:
           npm i -g @bahmutov/print-env
           print-env GITHUB
           print-env BUILD
+          cat $GITHUB_EVENT_PATH
 
       # Restore the previous NPM modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -25,6 +25,7 @@ jobs:
           npm i -g @bahmutov/print-env
           print-env GITHUB
           print-env BUILD
+          print-env ACTIONS
           cat $GITHUB_EVENT_PATH
 
       # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#contexts

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -3,14 +3,7 @@
 # good list of examples at http://www.thedreaming.org/2019/09/10/github-ci/
 name: Cypress parallel tests
 
-# when we have branched and open a pull request, we run these actions
-# we also want to run actions when changes land in master branch
-on:
-  push:
-    branches:
-    - master
-  pull_request:
-    - '*'
+on: push
 
 jobs:
   install:

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Print matrix object
         run: echo '${{ toJson(matrix) }}'
 
+      - name: Print Build object is any
+        run: echo '${{ toJson(Build) }}'
+
       # Restore the previous NPM modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire
       # workflow successfully finishes.

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -3,9 +3,14 @@
 # good list of examples at http://www.thedreaming.org/2019/09/10/github-ci/
 name: Cypress parallel tests
 
-# trigger on regular "internal" pushes and on pull requests
-# from external forks
-on: [push, pull_request]
+# when we have branched and open a pull request, we run these actions
+# we also want to run actions when changes land in master branch
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    - '*'
 
 jobs:
   install:

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -29,19 +29,19 @@ jobs:
 
       # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#contexts
       - name: Print job object
-        run: echo ${{ toJson(job) }}
+        run: echo '${{ toJson(job) }}'
 
       - name: Print steps object
-        run: echo ${{ toJson(steps) }}
+        run: echo '${{ toJson(steps) }}'
 
       - name: Print runner object
-        run: echo ${{ toJson(runner) }}
+        run: echo '${{ toJson(runner) }}'
 
       - name: Print strategy object
-        run: echo ${{ toJson(strategy) }}
+        run: echo '${{ toJson(strategy) }}'
 
       - name: Print matrix object
-        run: echo ${{ toJson(matrix) }}
+        run: echo '${{ toJson(matrix) }}'
 
       # Restore the previous NPM modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -44,9 +44,6 @@ jobs:
       - name: Print matrix object
         run: echo '${{ toJson(matrix) }}'
 
-      - name: Print Build object is any
-        run: echo '${{ toJson(Build) }}'
-
       # Restore the previous NPM modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire
       # workflow successfully finishes.

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -29,19 +29,19 @@ jobs:
 
       # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#contexts
       - name: Print job object
-        run: echo ${{ job }}
+        run: echo ${{ toJson(job) }}
 
       - name: Print steps object
-        run: echo ${{ steps }}
+        run: echo ${{ toJson(steps) }}
 
       - name: Print runner object
-        run: echo ${{ runner }}
+        run: echo ${{ toJson(runner) }}
 
       - name: Print strategy object
-        run: echo ${{ strategy }}
+        run: echo ${{ toJson(strategy) }}
 
       - name: Print matrix object
-        run: echo ${{ matrix }}
+        run: echo ${{ toJson(matrix) }}
 
       # Restore the previous NPM modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -2,14 +2,7 @@
 # https://help.github.com/en/articles/configuring-a-workflow
 name: Cypress tests
 
-# when we have branched and open a pull request, we run these actions
-# we also want to run actions when changes land in master branch
-on:
-  push:
-    branches:
-    - master
-  pull_request:
-    - '*'
+on: push
 
 jobs:
   test1:

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -2,9 +2,14 @@
 # https://help.github.com/en/articles/configuring-a-workflow
 name: Cypress tests
 
-# trigger on regular "internal" pushes and on pull requests
-# from external forks
-on: [push, pull_request]
+# when we have branched and open a pull request, we run these actions
+# we also want to run actions when changes land in master branch
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    - '*'
 
 jobs:
   test1:

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -10,6 +10,7 @@ jobs:
         uses: actions/checkout@v1
       - name: Cypress run
         uses: cypress-io/github-action@v1
+        timeout-minutes: 7
         with:
           build: npm run build
           start: npm start
@@ -30,6 +31,7 @@ jobs:
       # these containers will load balance all found tests among themselves
       - name: run tests
         uses: cypress-io/github-action@v1
+        timeout-minutes: 5
         with:
           record: true
           parallel: true
@@ -56,6 +58,7 @@ jobs:
       # these containers will load balance all found tests among themselves
       - name: run tests
         uses: cypress-io/github-action@v1
+        timeout-minutes: 5
         with:
           record: true
           parallel: true

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -7,6 +7,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Cypress run
-        uses: cypress-io/github-action@897222a
+        uses: cypress-io/github-action@8d4bcf0
         with:
-          start: npm start
+          start: npm start --verbose

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -1,49 +1,52 @@
+# Note: make sure to use the same version of cypress-io/github-action
+# in all jobs, otherwise the last version wins I believe
 name: Using Cypress GH Action
 on: [push, pull_request]
 jobs:
-  single-run:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: Cypress run
-        uses: cypress-io/github-action@22f7a76
-        with:
-          build: npm run build
-          start: npm start
-          wait-on: http://localhost:8080
+  # single-run:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v1
+  #     - name: Cypress run
+  #       uses: cypress-io/github-action@22f7a76
+  #       with:
+  #         build: npm run build
+  #         start: npm start
+  #         wait-on: http://localhost:8080
 
-  parallel-runs:
-    name: Parallel 4x
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # run 4 copies of the current job in parallel
-        containers: [1, 2, 3, 4]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
+  # parallel-runs:
+  #   name: Parallel 4x
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       # run 4 copies of the current job in parallel
+  #       containers: [1, 2, 3, 4]
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v1
 
-      # because of "record" and "parallel" parameters
-      # these containers will load balance all found tests among themselves
-      - name: run tests
-        uses: cypress-io/github-action@22f7a76
-        with:
-          record: true
-          parallel: true
-          group: 'GH Action parallel'
-          start: npm start
-        env:
-          # pass the Dashboard record key as an environment variable
-          CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}
+  #     # because of "record" and "parallel" parameters
+  #     # these containers will load balance all found tests among themselves
+  #     - name: run tests
+  #       uses: cypress-io/github-action@22f7a76
+  #       with:
+  #         record: true
+  #         parallel: true
+  #         group: GH Action parallel
+  #         start: npm start
+  #       env:
+  #         # pass the Dashboard record key as an environment variable
+  #         CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}
 
   parallel-runs-across-platforms:
     name: every OS
     strategy:
       matrix:
         # run 2 copies of the current job in parallel
-        containers: [1, 2]
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        # os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        os: ['windows-latest']
+        containers: [1, 2, 3, 4]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -52,11 +55,11 @@ jobs:
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@22f7a76
+        uses: cypress-io/github-action@1f3b5d3
         with:
           record: true
           parallel: true
-          group: 'Parallel 2x on ${{ matrix.os }}'
+          group: Parallel 2x on ${{ matrix.os }}
           start: npm start
         env:
           # pass the Dashboard record key as an environment variable

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -27,7 +27,7 @@ jobs:
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@v1
+        uses: cypress-io/github-action@22f7a76
         with:
           record: true
           parallel: true
@@ -38,7 +38,7 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}
 
   parallel-runs-across-platforms:
-    name: Parallel on each OS
+    name: every OS
     strategy:
       matrix:
         # run 2 copies of the current job in parallel

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -1,6 +1,7 @@
 # Note: make sure to use the same version of cypress-io/github-action
 # in all jobs, otherwise the last version wins I believe
 name: Using Cypress GH Action
+
 # when we have branched and open a pull request, we run these actions
 # we also want to run actions when changes land in master branch
 on:

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -7,6 +7,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Cypress run
-        uses: cypress-io/github-action@208d26b
+        uses: cypress-io/github-action@4718596
         with:
           start: npm start
+          wait-on: http://localhost:8080

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -60,7 +60,7 @@ jobs:
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@5657102
+        uses: cypress-io/github-action@6f9164e
         with:
           record: true
           parallel: true

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -55,7 +55,7 @@ jobs:
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@b81820f
+        uses: cypress-io/github-action@f32f3c9
         with:
           record: true
           parallel: true

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -55,7 +55,7 @@ jobs:
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@f32f3c9
+        uses: cypress-io/github-action@6d929c9
         with:
           record: true
           parallel: true

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -10,11 +10,10 @@ jobs:
         uses: actions/checkout@v1
       - name: Cypress run
         uses: cypress-io/github-action@v1
-        timeout-minutes: 7
+        timeout-minutes: 10
         with:
           build: npm run build
           start: npm start
-          wait-on: http://localhost:8080
 
   parallel-runs:
     name: Parallel 4x
@@ -58,7 +57,7 @@ jobs:
       # these containers will load balance all found tests among themselves
       - name: run tests
         uses: cypress-io/github-action@v1
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           record: true
           parallel: true

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -45,22 +45,17 @@ jobs:
     strategy:
       matrix:
         # run 2 copies of the current job in parallel
-        # os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        os: ['windows-latest']
-        containers: [1, 2, 3, 4]
+        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        containers: [1, 2]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1
 
-      # - uses: actions/setup-node@v1
-      #   with:
-      #     node-version: '12.x'
-
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@6f9164e
+        uses: cypress-io/github-action@v1
         with:
           record: true
           parallel: true

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -1,50 +1,50 @@
 # Note: make sure to use the same version of cypress-io/github-action
 # in all jobs, otherwise the last version wins I believe
 name: Using Cypress GH Action
-# on: [push, pull_request]
-on: 'push'
+on: [push, pull_request]
 jobs:
-  # single-run:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v1
-  #     - name: Cypress run
-  #       uses: cypress-io/github-action@22f7a76
-  #       with:
-  #         build: npm run build
-  #         start: npm start
-  #         wait-on: http://localhost:8080
+  single-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cypress run
+        uses: cypress-io/github-action@v1
+        with:
+          build: npm run build
+          start: npm start
+          wait-on: http://localhost:8080
 
-  # parallel-runs:
-  #   name: Parallel 4x
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       # run 4 copies of the current job in parallel
-  #       containers: [1, 2, 3, 4]
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v1
+  parallel-runs:
+    name: Parallel 4x
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # run 4 copies of the current job in parallel
+        containers: [1, 2, 3, 4]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
 
-  #     # because of "record" and "parallel" parameters
-  #     # these containers will load balance all found tests among themselves
-  #     - name: run tests
-  #       uses: cypress-io/github-action@22f7a76
-  #       with:
-  #         record: true
-  #         parallel: true
-  #         group: GH Action parallel
-  #         start: npm start
-  #       env:
-  #         # pass the Dashboard record key as an environment variable
-  #         CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}
+      # because of "record" and "parallel" parameters
+      # these containers will load balance all found tests among themselves
+      - name: run tests
+        uses: cypress-io/github-action@v1
+        with:
+          record: true
+          parallel: true
+          group: GH Action parallel
+          start: npm start
+        env:
+          # pass the Dashboard record key as an environment variable
+          CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}
 
   parallel-runs-across-platforms:
     name: every OS
     strategy:
       matrix:
         # run 2 copies of the current job in parallel
+        # and they will load balance all specs
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
         containers: [1, 2]
     runs-on: ${{ matrix.os }}
@@ -55,7 +55,7 @@ jobs:
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@d904abe
+        uses: cypress-io/github-action@v1
         with:
           record: true
           parallel: true
@@ -67,4 +67,3 @@ jobs:
         env:
           # pass the Dashboard record key as an environment variable
           CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}
-          DEBUG: cypress:cli

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -1,7 +1,15 @@
 # Note: make sure to use the same version of cypress-io/github-action
 # in all jobs, otherwise the last version wins I believe
 name: Using Cypress GH Action
-on: [push, pull_request]
+# when we have branched and open a pull request, we run these actions
+# we also want to run actions when changes land in master branch
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    - '*'
+
 jobs:
   single-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -23,7 +23,9 @@ jobs:
     strategy:
       matrix:
         # run 4 copies of the current job in parallel
-        containers: [1, 2, 3, 4]
+        # the actual items in the array do not matter
+        # we just need to "force" GitHub CI to create 4 jobs
+        machines: [1, 2, 3, 4]
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -49,7 +51,7 @@ jobs:
         # run 2 copies of the current job in parallel
         # and they will load balance all specs
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        containers: [1, 2]
+        machines: [1, 2]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -55,7 +55,7 @@ jobs:
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@6d929c9
+        uses: cypress-io/github-action@d904abe
         with:
           record: true
           parallel: true

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -7,7 +7,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Cypress run
-        uses: cypress-io/github-action@4718596
+        uses: cypress-io/github-action@e3c95c3
         with:
+          build: echo "Building app ..."
           start: npm start
           wait-on: http://localhost:8080

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -7,6 +7,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Cypress run
-        uses: cypress-io/github-action@v1
+        uses: cypress-io/github-action@897222a
         with:
           start: npm start

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -7,7 +7,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Cypress run
-        uses: cypress-io/github-action@8d4bcf0
+        uses: cypress-io/github-action@50e3ead
         with:
-          start: ls -la node_modules/.bin
-          # start: npm start --verbose
+          start: npm start

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -55,7 +55,7 @@ jobs:
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@v1
+        uses: cypress-io/github-action@b81820f
         with:
           record: true
           parallel: true

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -53,6 +53,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -56,7 +56,7 @@ jobs:
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@eba75a9
+        uses: cypress-io/github-action@0bb1882
         with:
           record: true
           parallel: true

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -14,7 +14,7 @@ jobs:
           wait-on: http://localhost:8080
 
   parallel-runs:
-    name: Cypress run
+    name: Parallel 4x
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -26,7 +26,7 @@ jobs:
 
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
-      - name: Parallel N=4
+      - name: run tests
         uses: cypress-io/github-action@v1
         with:
           record: true

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -7,7 +7,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Cypress run
-        uses: cypress-io/github-action@e3c95c3
+        uses: cypress-io/github-action@774910a
         with:
           build: npm run build
           start: npm start

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -1,0 +1,12 @@
+name: Using Cypress GH Action
+on: [push, pull_request]
+jobs:
+  cypress-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cypress run
+        uses: cypress-io/github-action@v1
+        with:
+          start: npm start

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -9,4 +9,5 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@8d4bcf0
         with:
-          start: npm start --verbose
+          start: ls -la node_modules/.bin
+          # start: npm start --verbose

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -7,7 +7,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Cypress run
-        uses: cypress-io/github-action@v1
+        uses: cypress-io/github-action@22f7a76
         with:
           build: npm run build
           start: npm start
@@ -52,7 +52,7 @@ jobs:
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@v1
+        uses: cypress-io/github-action@22f7a76
         with:
           record: true
           parallel: true

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -36,3 +36,28 @@ jobs:
         env:
           # pass the Dashboard record key as an environment variable
           CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}
+
+  parallel-runs-across-platforms:
+    name: Parallel on each OS
+    strategy:
+      matrix:
+        # run 2 copies of the current job in parallel
+        containers: [1, 2]
+        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      # because of "record" and "parallel" parameters
+      # these containers will load balance all found tests among themselves
+      - name: run tests
+        uses: cypress-io/github-action@v1
+        with:
+          record: true
+          parallel: true
+          group: 'Parallel 2x on ${{ matrix.os }}'
+          start: npm start
+        env:
+          # pass the Dashboard record key as an environment variable
+          CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -7,7 +7,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Cypress run
-        uses: cypress-io/github-action@774910a
+        uses: cypress-io/github-action@5a90794
         with:
           build: npm run build
           start: npm start

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -7,7 +7,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Cypress run
-        uses: cypress-io/github-action@5a90794
+        uses: cypress-io/github-action@v1
         with:
           build: npm run build
           start: npm start

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -2,14 +2,7 @@
 # in all jobs, otherwise the last version wins I believe
 name: Using Cypress GH Action
 
-# when we have branched and open a pull request, we run these actions
-# we also want to run actions when changes land in master branch
-on:
-  push:
-    branches:
-    - master
-  pull_request:
-    - '*'
+on: push
 
 jobs:
   single-run:

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -7,6 +7,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Cypress run
-        uses: cypress-io/github-action@a6c737f
+        uses: cypress-io/github-action@208d26b
         with:
           start: npm start

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -1,7 +1,7 @@
 name: Using Cypress GH Action
 on: [push, pull_request]
 jobs:
-  cypress-run:
+  single-run:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -12,3 +12,27 @@ jobs:
           build: npm run build
           start: npm start
           wait-on: http://localhost:8080
+
+  parallel-runs:
+    name: Cypress run
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # run 4 copies of the current job in parallel
+        containers: [1, 2, 3, 4]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      # because of "record" and "parallel" parameters
+      # these containers will load balance all found tests among themselves
+      - name: Cypress run
+        uses: cypress-io/github-action@v1
+        with:
+          record: true
+          parallel: true
+          group: 'GH Action parallel'
+          start: npm start
+        env:
+          # pass the Dashboard record key as an environment variable
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -1,7 +1,8 @@
 # Note: make sure to use the same version of cypress-io/github-action
 # in all jobs, otherwise the last version wins I believe
 name: Using Cypress GH Action
-on: [push, pull_request]
+# on: [push, pull_request]
+on: 'push'
 jobs:
   # single-run:
   #   runs-on: ubuntu-latest
@@ -55,7 +56,7 @@ jobs:
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@1f3b5d3
+        uses: cypress-io/github-action@eba75a9
         with:
           record: true
           parallel: true

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -26,7 +26,7 @@ jobs:
 
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
-      - name: Cypress run
+      - name: Parallel N=4
         uses: cypress-io/github-action@v1
         with:
           record: true

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -60,12 +60,15 @@ jobs:
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@cca4a0e
+        uses: cypress-io/github-action@5657102
         with:
           record: true
           parallel: true
           group: Parallel 2x on ${{ matrix.os }}
+          # on Mac and Linux we can use "npm start"
           start: npm start
+          # but for this particular project on Windows we need a different start command
+          start-windows: npm run start:ci:windows
         env:
           # pass the Dashboard record key as an environment variable
           CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -35,4 +35,4 @@ jobs:
           start: npm start
         env:
           # pass the Dashboard record key as an environment variable
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -9,6 +9,6 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@e3c95c3
         with:
-          build: echo "Building app ..."
+          build: npm run build
           start: npm start
           wait-on: http://localhost:8080

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -67,3 +67,4 @@ jobs:
         env:
           # pass the Dashboard record key as an environment variable
           CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}
+          DEBUG: cypress:cli

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -53,14 +53,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
+      # - uses: actions/setup-node@v1
+      #   with:
+      #     node-version: '12.x'
 
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@600a9e7
+        uses: cypress-io/github-action@cca4a0e
         with:
           record: true
           parallel: true

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -56,7 +56,7 @@ jobs:
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@0bb1882
+        uses: cypress-io/github-action@600a9e7
         with:
           record: true
           parallel: true

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -7,6 +7,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Cypress run
-        uses: cypress-io/github-action@50e3ead
+        uses: cypress-io/github-action@a6c737f
         with:
           start: npm start


### PR DESCRIPTION
Added example with single and parallel tests using new version of Cypress.io GitHub Action https://github.com/cypress-io/github-action

I say we start using Cypress GitHub Action and then figure out how to show it in our table of CIs (since we also have "normal" GitHub Action examples without our Cypress Action)

Good to go - the failures are flake