### PR TITLE
Fix grammar: a files contents -> file contents

### DIFF
--- a/cypress/integration/examples/files.spec.js
+++ b/cypress/integration/examples/files.spec.js
@@ -74,7 +74,7 @@ context('Files', () => {
       .should('deep.equal', requiredExample)
   })
 
-  it('cy.readFile() - read a files contents', () => {
+  it('cy.readFile() - read file contents', () => {
     // https://on.cypress.io/readfile
 
     // You can read a file and yield its contents


### PR DESCRIPTION
Change “read a files contents” to “read file contents”.