### PR TITLE
Fix mochawesome-merge command after breaking change in v4.0.0

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -15,6 +15,12 @@ frontend:
     paths:
       - node_modules/**/*
 test:
+  artifacts:
+    baseDirectory: cypress
+    configFilePath: "**/mochawesome.json"
+    files:
+      - "**/*.png"
+      - "**/*.mp4"
   phases:
     preTest:
       commands:
@@ -28,9 +34,3 @@ test:
     postTest:
       commands:
         - npx mochawesome-merge cypress/report/mochawesome-report > cypress/report/mochawesome.json
-  artifacts:
-    baseDirectory: test/cypress
-    configFilePath: "**/mochawesome.json"
-    files:
-      - "**/*.png"
-      - "**/*.mp4"

--- a/amplify.yml
+++ b/amplify.yml
@@ -33,4 +33,4 @@ test:
         - 'npx cypress run --reporter mochawesome --reporter-options "reportDir=cypress/report/mochawesome-report,overwrite=false,html=false,json=true,timestamp=mmddyyyy_HHMMss"'
     postTest:
       commands:
-        - npx mochawesome-merge --reportDir cypress/report/mochawesome-report > cypress/report/mochawesome.json
+        - npx mochawesome-merge cypress/report/mochawesome-report > cypress/report/mochawesome.json

--- a/amplify.yml
+++ b/amplify.yml
@@ -15,12 +15,6 @@ frontend:
     paths:
       - node_modules/**/*
 test:
-  artifacts:
-    baseDirectory: cypress
-    configFilePath: "**/mochawesome.json"
-    files:
-      - "**/*.png"
-      - "**/*.mp4"
   phases:
     preTest:
       commands:
@@ -34,3 +28,9 @@ test:
     postTest:
       commands:
         - npx mochawesome-merge cypress/report/mochawesome-report > cypress/report/mochawesome.json
+  artifacts:
+    baseDirectory: test/cypress
+    configFilePath: "**/mochawesome.json"
+    files:
+      - "**/*.png"
+      - "**/*.mp4"


### PR DESCRIPTION
See https://github.com/aws-amplify/amplify-console/issues/352 for explanation of the issue.

This fixes the `mochawesome-merge` command after 4.0.0 broke the CLI api.