### PR TITLE
Clarify comments in azure-ci.yml

### DIFF
--- a/azure-ci.yml
+++ b/azure-ci.yml
@@ -49,9 +49,9 @@ jobs:
         displayName: 'Cypress info'
 
       # The next command starts the server and runs Cypress end-to-end tests against it.
-      # The test artifacts (video, screenshots, test output) will be uploaded to Cypress dashboard
-      # To record on Cypress dashboard we need to set CYPRESS_RECORD_KEY environment variable
-      # environment variable BUILD_BUILDNUMBER is a good candidate
+      # The test artifacts (video, screenshots, test output) will be uploaded to Cypress dashboard.
+      # To record on Cypress dashboard we need to set CYPRESS_RECORD_KEY environment variable.
+      # For setting ci-build-id, BUILD_BUILDNUMBER is a good candidate
       - script: |
           npx print-env AGENT
           npx print-env BUILD


### PR DESCRIPTION
These rows in conjunction got me confused for a while:

      # To record on Cypress dashboard we need to set CYPRESS_RECORD_KEY environment variable
      # environment variable BUILD_BUILDNUMBER is a good candidate

As an unexperienced Cypress user, I assumed the RECORD_KEY was supposed to be my BUILDNUMBER.

This is clearly not the case, since the following error will be produced:
> Errors: [ "data.recordKey must be uuid format" ]

My change should suffice to clarify that doubt, but I'm sure you as domain experts can improve it as well.