### PR TITLE
copy cypress.env.json into docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY package.json package-lock.json ./
 COPY app ./app
 COPY serve.json ./
 # copy Cypress tests
-COPY cypress.json cypress ./
+COPY cypress.json cypress.env.json cypress ./
 COPY cypress ./cypress
 
 # avoid many lines of progress bars during install


### PR DESCRIPTION
`cypress.env.json` contains env variables and it must be copied into docker container if available