### PR TITLE
fix: Screenshot.defaults

### DIFF
--- a/cypress/integration/examples/misc.spec.js
+++ b/cypress/integration/examples/misc.spec.js
@@ -90,6 +90,7 @@ context('Misc', () => {
         disableTimersAndAnimations: true,
         screenshotOnRunFailure: true,
         // TODO: remove this when Cypress typedefs are fixed
+        // https://github.com/cypress-io/cypress/pull/7445
         // @ts-ignore
         onBeforeScreenshot () { },
         onAfterScreenshot () { },

--- a/cypress/integration/examples/misc.spec.js
+++ b/cypress/integration/examples/misc.spec.js
@@ -89,6 +89,8 @@ context('Misc', () => {
         scale: false,
         disableTimersAndAnimations: true,
         screenshotOnRunFailure: true,
+        // TODO: remove this when Cypress typedefs are fixed
+        // @ts-ignore
         onBeforeScreenshot () { },
         onAfterScreenshot () { },
       })

--- a/cypress/integration/examples/misc.spec.js
+++ b/cypress/integration/examples/misc.spec.js
@@ -89,8 +89,8 @@ context('Misc', () => {
         scale: false,
         disableTimersAndAnimations: true,
         screenshotOnRunFailure: true,
-        beforeScreenshot () { },
-        afterScreenshot () { },
+        onBeforeScreenshot () { },
+        onAfterScreenshot () { },
       })
     })
   })


### PR DESCRIPTION
fix usage of `Cypress.Screenshot.defaults()`


- tests will fail since Cypress typedefs are incorrect