### PR TITLE
fix: prepare for Cypress v4.7.1 release

### DIFF
--- a/cypress/integration/examples/misc.spec.js
+++ b/cypress/integration/examples/misc.spec.js
@@ -89,9 +89,6 @@ context('Misc', () => {
         scale: false,
         disableTimersAndAnimations: true,
         screenshotOnRunFailure: true,
-        // TODO: remove this when Cypress typedefs are fixed
-        // https://github.com/cypress-io/cypress/pull/7445
-        // @ts-ignore
         onBeforeScreenshot () { },
         onAfterScreenshot () { },
       })


### PR DESCRIPTION
- remove ts-ignore for screenshot defaults

To merge:

- when `develop` branch from Cypress passes with this branch, right before the test runner release, merge this PR and publish new Cypress version
- update the example version in the Test Runner and release version 4.7.1