### PR TITLE
Jenkins example is missing an argument to avoid a default double test run

### DIFF
--- a/basic/Jenkinsfile
+++ b/basic/Jenkinsfile
@@ -3,6 +3,9 @@ pipeline {
     // this image provides everything needed to run Cypress
     docker {
       image 'cypress/base:10'
+      // the default entrypoint is 'cypress run' which will run tests
+      // as we are running them through the npm script below we are disabling it
+      args '--entrypoint=""'
     }
   }
 


### PR DESCRIPTION
My tests are running twice with the given example. This example runs cypress through an npm command but it's also run via the default entrypoint of the docker contrainer. So we need to disable that entrypoint.