### PR TITLE
update Buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,25 +2,25 @@ env:
   TERM: "xterm"
 
 steps:
-  - command: "node --version"
-  - command: "npm --version"
-  - command: "npm install"
-    label: "install dependencies"
-  - "wait"
+  - command: |
+      echo "--- Node version"
+      node --version
 
-  # if necessary, reinstall "correct" version of Cypress
-  # a common situation if testing preview binary build
-  # - command: "$(npm bin)/cypress install --force"
-  # - "wait"
+      echo "--- NPM version"
+      npm --version
 
-  - command: "npm install $CYPRESS_NPM_PACKAGE_NAME"
-    label: "install custom Cypress version"
+      echo "--- Install NPM dependencies"
+      npm install
 
-  - "wait"
+      # if necessary, reinstall "correct" version of Cypress
+      # a common situation if testing preview binary build
+      # "$(npm bin)/cypress" install --force
+      #
+      echo "--- Install custom Cypress version"
+      npm install "$CYPRESS_NPM_PACKAGE_NAME"
 
-  - command: "$(npm bin)/cypress version"
+      echo "--- Cypress version"
+      "$(npm bin)/cypress" version
 
-  - "wait"
-
-  - command: "npm run test:ci:record"
-    label: "test"
+      echo "+++ Run Cypress tests"
+      npm run test:ci:record

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,8 @@ env:
   TERM: "xterm"
 
 steps:
-  - command: |
+  - label: ":cypress: Cypress"
+    command: |
       echo "--- Node version"
       node --version
 


### PR DESCRIPTION
Buildkite [command steps](https://buildkite.com/docs/pipelines/command-step) can and often do happen across multiple [agents](https://buildkite.com/docs/agent/v3) (usually on different hosts), so work to prepare and then run a command should be done within a single step. This also adds some [log output grouping](https://buildkite.com/docs/pipelines/managing-log-output) and uses shell escaping so that paths with spaces won't break.

I don't have Cypress set up enough to get a passing build, but here's what it looks like:

<img width="1277" alt="image" src="https://user-images.githubusercontent.com/14028/90203197-6b154880-de23-11ea-80b4-c2a191d6ae58.png">