### PR TITLE
Add AWS CodeBuild Basic and Parallel config file examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ To see the kitchen sink application, visit [example.cypress.io](https://example.
 CI | Build status | basic config file | full parallel config
 :--- | :--- | :--- | :---
 AWS Amplify Console | | [amplify.yml](amplify.yml) |
+AWS CodeBuild | | [basic/buildspec.yml](./basic/buildspec.yml) | [buildspec.yml](buildspec.yml)
 AppVeyor | [![AppVeyor CI](https://ci.appveyor.com/api/projects/status/bo4x59pha1eb18de?svg=true)](https://ci.appveyor.com/project/cypress-io/cypress-example-kitchensink) | [appveyor.yml](appveyor.yml)
 Azure CI | [![Build Status](https://cypress-io.visualstudio.com/cypress-example-kitchensink/_apis/build/status/cypress-io.cypress-example-kitchensink?branchName=master)](https://cypress-io.visualstudio.com/cypress-example-kitchensink/_build/latest?definitionId=2&branchName=master) | [basic/azure-ci.yml](basic/azure-ci.yml) | [azure-ci.yml](azure-ci.yml)
 Buddy | [![buddy pipeline](https://app.buddy.works/buddycypressexample/cypress-example-kitchensink/pipelines/pipeline/258967/badge.svg?token=09eff3f6e56b80bba931f3fc028b948dcdb2e1343402e32d08ff78cae4a06169 )](https://app.buddy.works/buddycypressexample/cypress-example-kitchensink/pipelines/pipeline/258967) | [buddy.yml](buddy.yml)

--- a/basic/buildspec.yml
+++ b/basic/buildspec.yml
@@ -1,0 +1,16 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      nodejs: 10
+    commands:
+      - npm ci
+  pre_build:
+    commands:
+      - npm run cy:verify
+      - npm run cy:info
+  build:
+    commands:
+        - npm run start:ci &
+        - npx cypress run --record

--- a/basic/buildspec.yml
+++ b/basic/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 12
+      nodejs: latest
     commands:
       - npm ci
   pre_build:

--- a/basic/buildspec.yml
+++ b/basic/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 10
+      nodejs: 12
     commands:
       - npm ci
   pre_build:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -40,7 +40,7 @@ phases:
   build:
     # Per https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
     # use $CODEBUILD_INITIATOR as it provides the entity that started the build
-    # which can be used as a unique identifier for the build in the Cypress Dashboard
+    # which is unique and can be used as the --ci-build-id for the Cypress Dashboard
     # e.g. awsCodeBuild-cypress-kitchen-sink/AWSCodeBuild-a14fc8e3-b5d6-42f9-9067-345d48a8f0fd
     commands:
         - npm run start:ci &

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,30 +2,24 @@ version: 0.2
 
 # AWS CodeBuild Batch configuration
 # https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html
-# Define 5 parallel builds to run using the "cypress/base" image on DockerHub
-batch:
-  fast-fail: false
-  build-list:
-    - identifier: cypress1
+# Define 5 parallel builds to run using the "build-matrix"
+build-matrix:
+    static:
+      ignore-failure: false
+      env:
+        type: LINUX_CONTAINER
+    dynamic:
       env:
         variables:
-          IMAGE: cypress/base
-    - identifier: cypress2
-      env:
-        variables:
-          IMAGE: cypress/base
-    - identifier: cypress3
-      env:
-        variables:
-          IMAGE: cypress/base
-    - identifier: cypress4
-      env:
-        variables:
-          IMAGE: cypress/base
-    - identifier: cypress5
-      env:
-        variables:
-          IMAGE: cypress/base
+          WORKERS:
+            - 1
+            - 2
+            - 3
+            - 4
+            - 5
+        # Optional: Use Custom Public ECR Image as container
+        #image:
+        #  - public.ecr.aws/your-namespace/image-name
 
 phases:
   install:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -24,7 +24,7 @@ build-matrix:
 phases:
   install:
     runtime-versions:
-      nodejs: 12
+      nodejs: latest
     commands:
       - npm ci
   pre_build:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,47 @@
+version: 0.2
+
+# AWS CodeBuild Batch configuration
+# https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html
+# Define 5 parallel builds to run using the "cypress/base" image on DockerHub
+batch:
+  fast-fail: false
+  build-list:
+    - identifier: cypress1
+      env:
+        variables:
+          IMAGE: cypress/base
+    - identifier: cypress2
+      env:
+        variables:
+          IMAGE: cypress/base
+    - identifier: cypress3
+      env:
+        variables:
+          IMAGE: cypress/base
+    - identifier: cypress4
+      env:
+        variables:
+          IMAGE: cypress/base
+    - identifier: cypress5
+      env:
+        variables:
+          IMAGE: cypress/base
+
+phases:
+  install:
+    runtime-versions:
+      nodejs: 10
+    commands:
+      - npm ci
+  pre_build:
+    commands:
+      - npm run cy:verify
+      - npm run cy:info
+  build:
+    # Per https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
+    # use $CODEBUILD_INITIATOR as it provides the entity that started the build
+    # which can be used as a unique identifier for the build in the Cypress Dashboard
+    # e.g. awsCodeBuild-cypress-kitchen-sink/AWSCodeBuild-a14fc8e3-b5d6-42f9-9067-345d48a8f0fd
+    commands:
+        - npm run start:ci &
+        - npx cypress run --record --parallel --ci-build-id $CODEBUILD_INITIATOR

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -24,7 +24,7 @@ build-matrix:
 phases:
   install:
     runtime-versions:
-      nodejs: 10
+      nodejs: 12
     commands:
       - npm ci
   pre_build:


### PR DESCRIPTION
Defines a basic and parallel example for using AWS CodeBuild.

The parallel config uses the newly released batched feature of AWS CodeBuild using the $CODEBUILD_INITIATOR as it provides the entity that started the build which is unique and can be used as the `--ci-build-id` for the Cypress Dashboard (e.g. `awsCodeBuild-cypress-kitchen-sink/AWSCodeBuild-a14fc8e3-b5d6-42f9-9067-345d48a8f0fd`)

- https://aws.amazon.com/about-aws/whats-new/2020/07/aws-codebuild-now-supports-parallel-and-coordinated-executions-of-a-build-project/
- https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html
