### PR TITLE
Fix cy.intercept links

### DIFF
--- a/app/commands/network-requests.html
+++ b/app/commands/network-requests.html
@@ -142,8 +142,8 @@ cy.request('https://jsonplaceholder.cypress.io/users?_limit=1')
         <div class="col-xs-12"><hr></div>
 
         <div class="col-xs-7">
-          <h4 id="http"><a href="https://on.cypress.io/http">cy.intercept()</a></h4>
-          <p>To route responses to matching requests, use the <a href="https://on.cypress.io/http"><code>cy.intercept()</code></a> command.</p>
+          <h4 id="http"><a href="https://on.cypress.io/intercept">cy.intercept()</a></h4>
+          <p>To route responses to matching requests, use the <a href="https://on.cypress.io/intercept"><code>cy.intercept()</code></a> command.</p>
           <pre><code class="javascript">    let message = 'whoa, this comment does not exist'
 
 // Listen to GET to comments/1

--- a/cypress/integration/examples/network_requests.spec.js
+++ b/cypress/integration/examples/network_requests.spec.js
@@ -114,7 +114,7 @@ context('Network Requests', () => {
   })
 
   it('cy.intercept() - route responses to matching requests', () => {
-    // https://on.cypress.io/http
+    // https://on.cypress.io/intercept
 
     let message = 'whoa, this comment does not exist'
 


### PR DESCRIPTION
Please note that there are other broken links that land to these 404 pages
- https://docs.cypress.io/dashboard-service
- https://docs.cypress.io/api/commands/.html
- https://docs.cypress.io/scrollTo
- https://docs.cypress.io/prevAll
- https://docs.cypress.io/prevUntil
