### PR TITLE
feat: Remove Cypress.moment() usage from examples

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -266,7 +266,6 @@
               <li><a href="/utilities">$</a></li>
               <li><a href="/utilities">Blob</a></li>
               <li><a href="/utilities">minimatch</a></li>
-              <li><a href="/utilities">moment</a></li>
               <li><a href="/utilities">Promise</a></li>
             </ul>
           </li>

--- a/app/utilities.html
+++ b/app/utilities.html
@@ -148,40 +148,6 @@ cy.wrap($li)
 
         <div class="col-xs-12"><hr></div>
 
-        <div class="col-xs-7">
-          <h4 id="moment"><a href="https://on.cypress.io/moment">Cypress.moment()</a></h4>
-          <p>To parse or format a date using a moment method, use the <a href="https://on.cypress.io/moment"><code>Cypress.moment()</code></a> command.</p>
-          <pre><code class="javascript">const time = Cypress.moment().utc('2014-04-25T19:38:53.196Z').format('h:mm A')
-
-cy.get('.utility-moment').contains('3:38 PM')
-  .should('have.class', 'badge')
-
-// the time in the element should be between 3pm and 5pm
-const start = Cypress.moment('3:00 PM', 'LT')
-const end = Cypress.moment('5:00 PM', 'LT')
-
-cy.get('.utility-moment .badge')
-  .should(($el) => {
-    // parse American time like "3:38 PM"
-    const m = Cypress.moment($el.text().trim(), 'LT')
-
-    // display hours + minutes + AM|PM
-    const f = 'h:mm A'
-
-    expect(m.isBetween(start, end),
-      `${m.format(f)} should be between ${start.format(f)} and ${end.format(f)}`).to.be.true
-  })</code></pre>
-        </div>
-        <div class="col-xs-5">
-          <div class="well">
-            <div class="utility-moment"> Posted at
-              <span class="badge badge-primary">3:38 PM</span>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-xs-12"><hr></div>
-
         <div class="col-xs-12">
           <h4 id="Promise"><a href="https://on.cypress.io/promise">Cypress.Promise</a></h4>
           <p>To instantiate a new bluebird promise, use <a href="https://on.cypress.io/promise"><code> Cypress.Promise</code></a>.</p>

--- a/cypress/integration/examples/utilities.spec.js
+++ b/cypress/integration/examples/utilities.spec.js
@@ -76,32 +76,6 @@ context('Utilities', () => {
     expect(matching, 'comments').to.be.false
   })
 
-  it('Cypress.moment() - format or parse dates using a moment method', () => {
-    // https://on.cypress.io/moment
-    const time = Cypress.moment('2014-04-25T19:38:53.196Z').utc().format('h:mm A')
-
-    expect(time).to.be.a('string')
-
-    cy.get('.utility-moment').contains('3:38 PM')
-      .should('have.class', 'badge')
-
-    // the time in the element should be between 3pm and 5pm
-    const start = Cypress.moment('3:00 PM', 'LT')
-    const end = Cypress.moment('5:00 PM', 'LT')
-
-    cy.get('.utility-moment .badge')
-      .should(($el) => {
-        // parse American time like "3:38 PM"
-        const m = Cypress.moment($el.text().trim(), 'LT')
-
-        // display hours + minutes + AM|PM
-        const f = 'h:mm A'
-
-        expect(m.isBetween(start, end),
-          `${m.format(f)} should be between ${start.format(f)} and ${end.format(f)}`).to.be.true
-      })
-  })
-
   it('Cypress.Promise - instantiate a bluebird promise', () => {
     // https://on.cypress.io/promise
     let waited = false

--- a/shippable.yml
+++ b/shippable.yml
@@ -11,8 +11,7 @@
 env:
   # the record key should be secret, thus it is encrypted
   # http://docs.shippable.com/ci/env-vars/
-  - secure: BVEpGDVa62Pc2fJzblIbkUifF207qfQMMial+KYkp0KlcVtF/WT12jFQ6N6fNGQSZc8op2E+K/OnTFI3Lo6NueD85wHy6PZiHTgrAzFjCZpMksyY7Pu/n7SKQk1yVS9rTNqtdTdRoXGTDX3DgVErBYeTYv7/uyH5sL4/HiS7Y2iuEkXV30X6K6Qx/D3zH/EXZARwJoIk88xliJW9hkqP1UKAeOS4tuBY/ADQ0gxi8bi4Io1N+rQ+QZRHm8Buur5PnVLIQhwL7nS7mLUJvXTZOThqYLJ4P/9E6CBX1gviwQLo4KvyExv9zc18gyX5pJ/16fl94dKIJ6518EKPY6xRFQ==
-
+  - secure: N5+kC/lvCYBZPfneXH87gfwxkY0KzAuRrISAC3kKfGY9+NCRU7gHYdDq0c/Uh5GeBMZlvmUAlu+8b94qrwImm6jm1/w7LN/E9gey+SX6NdHkya5j8gW+n3Eiw8Z36at4KxIOyIDCL/6ZtmsM7fSS/iUfVHDvRw/ZnGKYBYuyG0emsgyZbx4Hmb0usSv1mJkwCN3FYML82DwUyi5fYwrkMQ4gssgUoWBWVXxFW+UdoA2wXrAvH19NF0awy1ZKFdLc18IjcScz7HMPALigDCLeyprrvQqwXJ5tNPRf0ClfP1bIPNKxRM/Cgj0Jnooh1RgevHbCtwjKpOHHWcZth8SbQw==
 build:
   # note: you can use custom Docker image with Shippable, see
   # http://docs.shippable.com/ci/custom-docker-image/


### PR DESCRIPTION
This removes deprecated `Cypress.moment()` from the scaffolded examples. 

I don’t *really* feel like this has to go out with 7.0.0 (where `Cypress.moment()` will be removed completely). It’s already deprecated so I think it’s ok to remove from the master example.