### PR TITLE
enable appveyor firefox testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,21 +9,23 @@ version: 2.1
 orbs:
   # use Cypress orb from CircleCI registry
   cypress: cypress-io/cypress@1.26.0
-  # for testing on Windows
-  # https://circleci.com/docs/2.0/hello-world-windows/
-  win: circleci/windows@1
 
 executors:
   mac:
     macos:
       xcode: "10.1.0"
+  win:
+    # copied the parameters from
+    # https://circleci.com/developer/orbs/orb/circleci/windows
+    machine:
+      image: "windows-server-2019-vs2019:stable"
+      resource_class: "windows.medium"
+      shell: "bash.exe"
 
 jobs:
   win-test:
     working_directory: ~/app
-    executor:
-      name: win/vs2019
-      shell: bash.exe
+    executor: win
     steps:
       - checkout
 
@@ -58,6 +60,45 @@ jobs:
       - store_artifacts:
           path: cypress\videos
 
+  win-test-chrome:
+    working_directory: ~/app
+    executor: win
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+
+      # install Chrome browser on Windows machine using Chocolatey
+      - run: choco install googlechrome
+      - run: npm ci
+      - run: npm run cy:verify
+      - run: npm run cy:info
+
+      - save_cache:
+          key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+          paths:
+            # could not use environment variables for some reason
+            - C:\Users\circleci\AppData\Local\Cypress\Cache
+            - C:\Users\circleci\AppData\Roaming\npm-cache
+
+      # if you want to test execa's behavior on Windows
+      # - run: node ./scripts/test-execa
+
+      - run:
+          name: 'Start server'
+          command: npm run start:ci:windows
+          background: true
+
+      - run:
+          name: 'Run Cypress tests'
+          command: npm run e2e:record:chrome -- --env circle=true
+          no_output_timeout: '1m'
+      - store_artifacts:
+          path: cypress\screenshots
+      - store_artifacts:
+          path: cypress\videos
+
   release:
     executor: cypress/base-10
     steps:
@@ -69,6 +110,7 @@ workflows:
   win-build:
     jobs:
       - win-test
+      - win-test-chrome
 
   mac-build:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ jobs:
           key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
 
       # install Chrome browser on Windows machine using Chocolatey
+      # https://chocolatey.org/packages/GoogleChrome
       - run: choco install googlechrome
       - run: npm ci
       - run: npm run cy:verify
@@ -99,6 +100,46 @@ jobs:
       - store_artifacts:
           path: cypress\videos
 
+  win-test-firefox:
+    working_directory: ~/app
+    executor: win
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+
+      # install Firefox browser on Windows machine using Chocolatey
+      # https://chocolatey.org/packages/Firefox
+      - run: choco install firefox
+      - run: npm ci
+      - run: npm run cy:verify
+      - run: npm run cy:info
+
+      - save_cache:
+          key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+          paths:
+            # could not use environment variables for some reason
+            - C:\Users\circleci\AppData\Local\Cypress\Cache
+            - C:\Users\circleci\AppData\Roaming\npm-cache
+
+      # if you want to test execa's behavior on Windows
+      # - run: node ./scripts/test-execa
+
+      - run:
+          name: 'Start server'
+          command: npm run start:ci:windows
+          background: true
+
+      - run:
+          name: 'Run Cypress tests'
+          command: npm run e2e:record:firefox -- --env circle=true
+          no_output_timeout: '1m'
+      - store_artifacts:
+          path: cypress\screenshots
+      - store_artifacts:
+          path: cypress\videos
+
   release:
     executor: cypress/base-10
     steps:
@@ -111,6 +152,7 @@ workflows:
     jobs:
       - win-test
       - win-test-chrome
+      - win-test-firefox
 
   mac-build:
     jobs:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ skip_commits:
 # https://www.appveyor.com/docs/lang/nodejs-iojs/
 # Test against the latest version of this Node.js version
 environment:
-  nodejs_version: "10"
+  nodejs_version: "12"
 
 # Install scripts. (runs after repo cloning)
 install:
@@ -36,12 +36,9 @@ test_script:
   - run-if npm run cy:info
   - run-if npm run cy:cache:list
 
-  # uses default Electron browser
+  - CYPRESS_defaultCommandTimeout=20000 run-if npm run test:ci:record:windows:chrome
   - run-if npm run test:ci:record:windows
-  # only enable once this is fixed
-  # https://github.com/cypress-io/cypress-example-kitchensink/issues/438
   - run-if npm run test:ci:record:windows:firefox
-  - run-if npm run test:ci:record:windows:chrome
   - run-if npm run test:ci:record:windows:edge
 
 # Don't actually build.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,11 @@ test_script:
   - run-if npm run cy:info
   - run-if npm run cy:cache:list
 
-  - CYPRESS_defaultCommandTimeout=20000 run-if npm run test:ci:record:windows:chrome
+  # noticed really slow execution of some specs on Windows
+  # leading to failures. Trying to increase the command timeout
+  # maybe it will solve it
+  - setx CYPRESS_defaultCommandTimeout 20000
+  - run-if npm run test:ci:record:windows:chrome
   - run-if npm run test:ci:record:windows
   - run-if npm run test:ci:record:windows:firefox
   - run-if npm run test:ci:record:windows:edge

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,12 +36,11 @@ test_script:
   - run-if npm run cy:info
   - run-if npm run cy:cache:list
 
-  # only enable once this is fixed
-  # https://github.com/cypress-io/cypress-example-kitchensink/issues/438
-  # fixed in https://github.com/cypress-io/cypress/issues/6813
-  # - run-if npm run test:ci:record:windows:firefox
   # uses default Electron browser
   - run-if npm run test:ci:record:windows
+  # only enable once this is fixed
+  # https://github.com/cypress-io/cypress-example-kitchensink/issues/438
+  - run-if npm run test:ci:record:windows:firefox
   - run-if npm run test:ci:record:windows:chrome
   - run-if npm run test:ci:record:windows:edge
 


### PR DESCRIPTION
- closes #474 by recording Circle Windows runs
- [x] Electron
- [x] Chrome
- [x] Firefox
- closes #438 and enabled Windows AppVeyor Firefox tests

Flakey test failures: https://github.com/cypress-io/cypress-example-kitchensink/issues/476 for FF on Windows, and Chrome on AppVeyor with very slow actions spec that fails on `click({ multiple: true })`