### PR TITLE
fix: remove window size changes from plugin file 

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -17,22 +17,6 @@
  */
 // eslint-disable-next-line no-unused-vars
 module.exports = (on, config) => {
-  on('before:browser:launch', (browser, launchOptions) => {
-    if (browser.name === 'chrome' && browser.isHeadless) {
-      launchOptions.args.push('--window-size=1280,720')
-      launchOptions.args.push('--force-device-scale-factor=1')
-    }
-
-    if (browser.name === 'electron' && browser.isHeadless) {
-      launchOptions.preferences.width = 1280
-      launchOptions.preferences.height = 720
-    }
-
-    if (browser.name === 'firefox' && browser.isHeadless) {
-      launchOptions.args.push('--width=1280')
-      launchOptions.args.push('--height=720')
-    }
-
-    return launchOptions
-  })
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
 }


### PR DESCRIPTION
Reverts some changes to the plugin file that would have made their way into scaffolding and not provided the user with an empty plugins file