### PR TITLE
Remove second arg from cy.wrap

### DIFF
--- a/cypress/integration/2-advanced-examples/files.spec.js
+++ b/cypress/integration/2-advanced-examples/files.spec.js
@@ -43,8 +43,7 @@ context('Files', () => {
       .to.deep.equal(requiredExample)
 
     // or use "cy.wrap" and "should('deep.equal', ...)" assertion
-    // @ts-ignore
-    cy.wrap(this.example, 'fixture vs require')
+    cy.wrap(this.example)
       .should('deep.equal', requiredExample)
   })
 


### PR DESCRIPTION
Address https://github.com/cypress-io/cypress/issues/16785

`cy.wrap()` accepts a `subject` and `options` arguments - not a string as a second arg. 

Remove erroneous second string arg from example.

