### PR TITLE
Support @typescript-eslint/no-unused-vars rule

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -15,7 +15,7 @@
 /**
  * @type {Cypress.PluginConfig}
  */
-// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config


### PR DESCRIPTION

### User facing changelog

This disables the ESLint [`@typescript-eslint/no-unused-vars`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md) rule (the typed counterpart to ESLint's built-in `no-unused-vars`)

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

The files scaffolded by Cypress create an error out of the box for those users who are using `@typescript-eslint/no-unused-vars` instead of `no-unused-vars`

This rule is also possible (and desirable) to use with JS files as well - it offers additional type information even in JS files so that the rule catches more problems.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Before: Error out of the box

![Screen Shot 2021-07-21 at 22 02 48](https://user-images.githubusercontent.com/1935696/126552752-8f6c8e4a-71b5-464e-89cf-97e766f98e44.png)


After: No error

![Screen Shot 2021-07-21 at 22 03 34](https://user-images.githubusercontent.com/1935696/126552730-77dd872a-1a4b-4090-b462-88ad9ee1925b.png)



Original PR: https://github.com/cypress-io/cypress/pull/17432

cc @flotwig 