### PR TITLE
Remove unnecessary click from example

### DIFF
--- a/app/utilities.html
+++ b/app/utilities.html
@@ -127,7 +127,7 @@ cy.wrap($li)
     // append the image
     $div.append(img)
 
-    cy.get('.utility-blob img').click()
+    cy.get('.utility-blob img')
       .should('have.attr', 'src', dataUrl)
   }))</code></pre>
         </div>

--- a/cypress/integration/2-advanced-examples/utilities.spec.js
+++ b/cypress/integration/2-advanced-examples/utilities.spec.js
@@ -40,7 +40,7 @@ context('Utilities', () => {
         // append the image
         $div.append(img)
 
-        cy.get('.utility-blob img').click()
+        cy.get('.utility-blob img')
           .should('have.attr', 'src', dataUrl)
       })
     })


### PR DESCRIPTION
While exploring Cypress examples from the Kitchen Sink App, I noticed this unnecessary `.click()`, so I'm removing it to simplify things and avoid confusion.