### PR TITLE
Update support for M1 + Fix on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ orbs:
 executors:
   mac:
     macos:
-      xcode: "12.2"
+      xcode: "13.2.1"
   win:
     # copied the parameters from
     # https://circleci.com/developer/orbs/orb/circleci/windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ orbs:
 executors:
   mac:
     macos:
-      xcode: "10.1.0"
+      xcode: "12.2"
   win:
     # copied the parameters from
     # https://circleci.com/developer/orbs/orb/circleci/windows

--- a/package-lock.json
+++ b/package-lock.json
@@ -11087,7 +11087,7 @@
     "puppeteer": {
       "version": "13.4.0",
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.4.0.tgz",
-      "integrity": "sha512-lqOLzqCKdh7yUAHvK6LxgOpQrL8Bv1/jvS8MLDXxcNms2rlM3E8p/Wlwc7efbRZ0twxTzUeqjN5EqrTwxOwc9g==",
+      "integrity": "sha512-WrHtFF2WpYC6KWFP4OCPOHWCjW4f8tFk+FkYZeNQ8/lHn+asjXBEXiIWauune8CY2xIHBVExGas+WI6Ay8/MgQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6866,7 +6866,7 @@
         "debug": "4.1.1",
         "got": "10.7.0",
         "local-web-server": "^4.2.1",
-        "puppeteer": "^7.0.1",
+        "puppeteer": "^13.4.0",
         "ramda": "0.27.1"
       },
       "dependencies": {
@@ -11085,8 +11085,8 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "puppeteer": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-7.1.0.tgz",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.4.0.tgz",
       "integrity": "sha512-lqOLzqCKdh7yUAHvK6LxgOpQrL8Bv1/jvS8MLDXxcNms2rlM3E8p/Wlwc7efbRZ0twxTzUeqjN5EqrTwxOwc9g==",
       "dev": true,
       "requires": {


### PR DESCRIPTION
- Update puppeteer dependencies to support newer M1 Processors
- Update Circle CI Mac executer to latest one (Old one was deprecated)