### PR TITLE
Replace placeholder images with divs

### DIFF
--- a/app/assets/css/styles.css
+++ b/app/assets/css/styles.css
@@ -51,6 +51,12 @@ canvas {
   margin-top: 2em;
 }
 
+.placeholder {
+  width: 100px;
+  height: 100px;
+  background: #69f;
+}
+
 /*---------nav----------*/
 
 .navbar {

--- a/app/commands/actions.html
+++ b/app/commands/actions.html
@@ -580,54 +580,54 @@ cy.get('#scrollable-both').scrollTo('center', { duration: 2000 })</code></pre>
         </div>
         <div class="col-xs-5">
           <div class="well">
-            <div id="scrollable-horizontal" style="height: 150px; width: 300px; overflow: auto;">
+            <div id="scrollable-horizontal" style="height: 200px; width: 300px; overflow: auto;">
               <div style="width: 3000px">
                 Horizontal Scroll
                 <ul>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                 </ul>
               </div>
@@ -638,28 +638,28 @@ cy.get('#scrollable-both').scrollTo('center', { duration: 2000 })</code></pre>
                 Vertical Scroll
                 <ul>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                   <li>
-                    <img src="https://placehold.it/100x100">
+                    <div class="placeholder"></div>
                   </li>
                 </ul>
               </div>


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-example-kitchensink/issues/539

Replaces placeholder images with styled divs. Also fixes the horizontal scrolling section to scroll only horizontally.