### PR TITLE
feat: Add e2e property to config

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   'projectId': '4b7344',
+  e2e: {}
 }


### PR DESCRIPTION
This PR is part of https://github.com/cypress-io/cypress/pull/22000 which close https://github.com/cypress-io/cypress/issues/21909

The idea is to have `e2e` or `component` property set on the config file to run the project in run mode - otherwise throw the correct error message