### PR TITLE
build: Updated cache tasks to most recent Azure DevOps tasks

### DIFF
--- a/basic/azure-ci.yml
+++ b/basic/azure-ci.yml
@@ -1,3 +1,7 @@
+variables:
+  npm_config_cache: $(Pipeline.Workspace)/.npm
+  cypress_binary_cache: $(HOME)/.cache/Cypress
+
 jobs:
   # Example job that runs end-to-end tests using Cypress test runner
   #   https://www.cypress.io/
@@ -14,22 +18,20 @@ jobs:
 
       # NPM modules and Cypress binary should be cached
       # otherwise the install will be too slow
-      # https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops
-      # since the username / user home directory are not available via system variables
-      # (there is even an open question about it)
-      # https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops
-      # just use "/home/vsts" for now
-      - task: CacheBeta@1
+      # https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops#nodejsnpm
+      - task: Cache@2
         inputs:
-          key: npm | $(Agent.OS) | package-lock.json
-          path: /home/vsts/.npm
-          restoreKeys: npm | $(Agent.OS) | package-lock.json
-        displayName: Cache NPM packages
-      - task: CacheBeta@1
+          key: 'npm | "$(Agent.OS)" | package-lock.json'
+          restoreKeys: |
+            npm | "$(Agent.OS)"
+          path: $(npm_config_cache)
+        displayName: Cache npm
+      - task: Cache@2
         inputs:
-          key: cypress | $(Agent.OS) | package-lock.json
-          path: /home/vsts/.cache/Cypress
-          restoreKeys: cypress | $(Agent.OS) | package-lock.json
+          key: 'cypress | "$(Agent.OS)" | package-lock.json'
+          restoreKeys: |
+            cypress | "$(Agent.OS)"
+          path: $(cypress_binary_cache)
         displayName: Cache Cypress binary
 
       - script: npm ci


### PR DESCRIPTION
The cache-task provided by Azure DevOps has continued to develop - this change brings the caching shown here in sync with https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops#nodejsnpm