### PR TITLE
chore: Remove deprecated Cookies.defaults/preserveOnce

### DIFF
--- a/app/cypress-api.html
+++ b/app/cypress-api.html
@@ -104,29 +104,6 @@ cy.setCookie('fakeCookie', '123ABC')
         <div class="col-xs-12"><hr></div>
 
         <div class="col-xs-12">
-          <h4 id="Cookies.preserveOnce"><a href="https://on.cypress.io/cookies">Cypress.Cookies.preserveOnce()</a></h4>
-          <p>To preserve cookies by its key, use <a href="https://on.cypress.io/cookies"><code>Cypress.Cookies.preserveOnce()</code></a>.</p>
-          <pre><code class="javascript">cy.getCookie('fakeCookie').should('not.be.ok')
-
-// preserving a cookie will not clear it when
-// the next test starts
-cy.setCookie('lastCookie', '789XYZ')
-Cypress.Cookies.preserveOnce('lastCookie')</code></pre>
-        </div>
-
-        <div class="col-xs-12"><hr></div>
-
-        <div class="col-xs-12">
-          <h4 id="Cookies.default"><a href="https://on.cypress.io/cookies">Cypress.Cookies.default()</a></h4>
-          <p>To set defaults for all cookies, use <a href="https://on.cypress.io/cookies"><code>Cypress.Cookies.default()</code></a>.</p>
-          <pre><code class="javascript">Cypress.Cookies.defaults({
-  preserve: 'session_id'
-})</code></pre>
-        </div>
-
-        <div class="col-xs-12"><hr></div>
-
-        <div class="col-xs-12">
           <h4 id="arch"><a href="https://on.cypress.io/arch">Cypress.arch</a></h4>
           <p>To get CPU architecture name of underlying OS, use <a href="https://on.cypress.io/arch"><code>Cypress.arch</code></a>.</p>
           <pre><code class="javascript">expect(Cypress.arch).to.exist</code></pre>

--- a/cypress/e2e/2-advanced-examples/cypress_api.cy.js
+++ b/cypress/e2e/2-advanced-examples/cypress_api.cy.js
@@ -51,24 +51,6 @@ context('Cypress.Cookies', () => {
     cy.clearCookie('fakeCookie')
     cy.setCookie('fakeCookie', '123ABC')
   })
-
-  it('.preserveOnce() - preserve cookies by key', () => {
-    // normally cookies are reset after each test
-    cy.getCookie('fakeCookie').should('not.be.ok')
-
-    // preserving a cookie will not clear it when
-    // the next test starts
-    cy.setCookie('lastCookie', '789XYZ')
-    Cypress.Cookies.preserveOnce('lastCookie')
-  })
-
-  it('.defaults() - set defaults for all cookies', () => {
-    // now any cookie with the name 'session_id' will
-    // not be cleared before each new test runs
-    Cypress.Cookies.defaults({
-      preserve: 'session_id',
-    })
-  })
 })
 
 context('Cypress.arch', () => {


### PR DESCRIPTION
`Cypress.Cookies.defaults` and `Cypress.Cookies.preserveOnce` were deprecated in Cypress version 9.7.0 and are being completely removed in Cypress version 11.0.0. The functionality has been replaced with `cy.session`. 