### PR TITLE
fix: .should() new behavior

### DIFF
--- a/cypress/e2e/2-advanced-examples/connectors.cy.js
+++ b/cypress/e2e/2-advanced-examples/connectors.cy.js
@@ -25,12 +25,13 @@ context('Connectors', () => {
   it('.invoke() - invoke a function on the current subject', () => {
     // our div is hidden in our script.js
     // $('.connectors-div').hide()
+    cy.get('.connectors-div').should('be.hidden')
 
     // https://on.cypress.io/invoke
-    cy.get('.connectors-div').should('be.hidden')
-      // call the jquery method 'show' on the 'div.container'
-      .invoke('show')
-      .should('be.visible')
+    // call the jquery method 'show' on the 'div.container'
+    cy.get('.connectors-div').invoke('show')
+
+    cy.get('.connectors-div').should('be.visible')
   })
 
   it('.spread() - spread an array as individual args to callback function', () => {


### PR DESCRIPTION
Related monorepo PR: https://github.com/cypress-io/cypress/pull/25296

Basically, .should() will no longer break query chains. So in this example, 

```
cy.get('.connectors-div')
  .should('be.hidden') // This assertion
  .invoke('show')
  .should('be.visible') // And this assertion can never be true on the same subject at the same time.
```