### PR TITLE
chore(deps): uninstall unused stop-build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "netlify-plugin-cypress": "2.0.0",
         "semantic-release": "15.13.32",
         "start-server-and-test": "1.10.11",
-        "stop-build": "1.1.0",
         "yaml-lint": "1.2.4"
       },
       "engines": {
@@ -1594,12 +1593,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "dev": true
-    },
     "node_modules/asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -2190,47 +2183,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
-    },
-    "node_modules/chdir-promise": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.4.0.tgz",
-      "integrity": "sha512-fAvt/5sjLFKVp5bOc6FnMWB7kcXHk1uZSQa6tWdkkcT/Dv/hmsVwuabyDujd6G7a17mZipoYLJEaQcSEYrTG6Q==",
-      "dev": true,
-      "dependencies": {
-        "check-more-types": "2.23.0",
-        "debug": "^2.3.3",
-        "lazy-ass": "1.5.0",
-        "q": "1.1.2",
-        "spots": "0.4.0"
-      }
-    },
-    "node_modules/chdir-promise/node_modules/check-more-types": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
-      "integrity": "sha512-dDo5EKT4pZj5GArqso+z2TJmk5/fb+MqtwqJO4IdVhmL9rjglTvndCTRRwxDlQT9FObaYJENljJ0A+8ckAYakQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/chdir-promise/node_modules/lazy-ass": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
-      "integrity": "sha512-5l6J7+KWp/OiisiR/KkwuPgeaIyb8d5jlLZsncDpffa5aBtOCcEcyoXoMGxOw50fr7RrCxEGqXkIHGRl1PL7ig==",
-      "dev": true,
-      "engines": {
-        "node": "> 0.8"
-      }
-    },
-    "node_modules/chdir-promise/node_modules/q": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-      "integrity": "sha512-ROtylwux7Vkc4C07oKE/ReigUmb33kVoLtcR4SJ1QVqwaZkBEDL3vX4/kwFzIERQ5PfCl0XafbU8u2YUhyGgVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
     },
     "node_modules/check-more-types": {
       "version": "2.24.0",
@@ -3377,15 +3329,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "node_modules/d3-helpers": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/d3-helpers/-/d3-helpers-0.3.0.tgz",
-      "integrity": "sha512-uNJ5QRsTW7CdNC6CHX528VwIEzYCC/iFHMQ9ReaDUGA+iiJXHcR2uKobK68FkKSWmNYPxwaUV+9SswjoygF6VA==",
-      "dev": true,
-      "engines": {
-        "node": "> 0.8"
-      }
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -5262,140 +5205,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "node_modules/ggit": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/ggit/-/ggit-1.15.1.tgz",
-      "integrity": "sha512-xfdO/qLRT2Xqv8sZgom726ZhWmBBjhTd6qKhEZ1LnRzAu14bN+qf+CGd/u1YJP0k18KEbC65gsW/pbKnNtOWzg==",
-      "dev": true,
-      "dependencies": {
-        "bluebird": "3.5.0",
-        "chdir-promise": "0.4.0",
-        "check-more-types": "2.24.0",
-        "cli-table": "0.3.1",
-        "colors": "1.1.2",
-        "commander": "2.9.0",
-        "d3-helpers": "0.3.0",
-        "debug": "2.6.3",
-        "glob": "7.1.1",
-        "lazy-ass": "1.6.0",
-        "lodash": "3.10.1",
-        "moment": "2.18.1",
-        "optimist": "0.6.1",
-        "q": "2.0.3",
-        "quote": "0.4.0",
-        "ramda": "0.9.1"
-      },
-      "bin": {
-        "ggit": "bin/ggit.js",
-        "ggit-last": "bin/ggit-last"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/ggit/node_modules/bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha512-3LE8m8bqjGdoxfvf71yhFNrUcwy3NLy00SAo+b6MfJ8l+Bc2DzQ7mUHwX6pjK2AxfgV+YfsjCeVW3T5HLQTBsQ==",
-      "dev": true
-    },
-    "node_modules/ggit/node_modules/cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha512-h/TzJrgwzVV+W6laITBZAxAWfBjX4T0x+LF5XJdS1AzDkXqmraMNnKQ/O/f3AHJKVR85fOglUEdS/B0P1wS7Aw==",
-      "dev": true,
-      "dependencies": {
-        "colors": "1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.2.0"
-      }
-    },
-    "node_modules/ggit/node_modules/cli-table/node_modules/colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/ggit/node_modules/colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha512-ENwblkFQpqqia6b++zLD/KUWafYlVY/UNnAp7oz7LY7E924wmpye416wBOmvv/HMWzl8gL1kJlfvId/1Dg176w==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/ggit/node_modules/commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==",
-      "dev": true,
-      "dependencies": {
-        "graceful-readlink": ">= 1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6.x"
-      }
-    },
-    "node_modules/ggit/node_modules/debug": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
-      "integrity": "sha512-9k275CFA9z/NW+7nojeyxyOCFYsc+Dfiq4Sg8CBP5WjzmJT5K1utEepahY7wuWhlsumHgmAqnwAnxPCgOOyAHA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "0.7.2"
-      }
-    },
-    "node_modules/ggit/node_modules/glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha512-mRyN/EsN2SyNhKWykF3eEGhDpeNplMWaW18Bmh76tnOqk5TbELAVwFAYOCmKVssOYFrYvvLMguiA+NXO3ZTuVA==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.2",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/ggit/node_modules/lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
-      "dev": true
-    },
-    "node_modules/ggit/node_modules/ms": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-      "integrity": "sha512-5NnE67nQSQDJHVahPJna1PQ/zCXMnQop3yUCxjKPNzCxuyPSKWTQ/5Gu5CZmjetwGLWRA+PzeF5thlbOdbQldA==",
-      "dev": true
-    },
-    "node_modules/ggit/node_modules/q": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/q/-/q-2.0.3.tgz",
-      "integrity": "sha512-gv6vLGcmAOg96/fgo3d9tvA4dJNZL3fMyBqVRrGxQ+Q/o4k9QzbJ3NQF9cOO/71wRodoXhaPgphvMFU68qVAJQ==",
-      "dev": true,
-      "dependencies": {
-        "asap": "^2.0.0",
-        "pop-iterate": "^1.0.1",
-        "weak-map": "^1.0.5"
-      }
-    },
-    "node_modules/ggit/node_modules/ramda": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.9.1.tgz",
-      "integrity": "sha512-Rccpyj5OM4v2ecM8Ej0canQkH4FSAu9o+mZezRl20/Uph1B1deJ26NjevZH4v7E0ngANvbKw7azX1a8v6KoBrQ==",
-      "dev": true
-    },
     "node_modules/git-hooks-list": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-1.0.3.tgz",
@@ -5823,12 +5632,6 @@
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
-    },
-    "node_modules/graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
-      "dev": true
     },
     "node_modules/handlebars": {
       "version": "4.7.7",
@@ -8795,15 +8598,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha512-QGcnVKRSEhbWy2i0pqFhjWMCczL/YU5ICMB3maUavFcyUqBszRnzsswvOaGOqSfWZ/R+dMnb9gGBuRT4LMTdVQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/morgan": {
@@ -14043,31 +13837,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      }
-    },
-    "node_modules/optimist/node_modules/minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
-      "dev": true
-    },
-    "node_modules/optimist/node_modules/wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -14528,21 +14297,6 @@
         "semver-compare": "^1.0.0"
       }
     },
-    "node_modules/pluralize": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-5.0.0.tgz",
-      "integrity": "sha512-3XyqUZZQZhBf6vt9FP49WhY+ZeqYT7Y6pWn4uWCAifD5tganssOlrsLbMysFM1Rgnmd9k2OUsgvDe7jWSXrchQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pop-iterate": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pop-iterate/-/pop-iterate-1.0.1.tgz",
-      "integrity": "sha512-HRCx4+KJE30JhX84wBN4+vja9bNfysxg1y28l0DuJmkoaICiv2ZSilKddbS48pq50P8d2erAhqDLbp47yv3MbQ==",
-      "dev": true
-    },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -14806,12 +14560,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/quote": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
-      "integrity": "sha512-KHp3y3xDjuBhRx+tYKOgzPnVHMRlgpn2rU450GcU4PL24r1H6ls/hfPrxDwX2pvYMlwODHI2l8WwgoV69x5rUQ==",
-      "dev": true
     },
     "node_modules/ramda": {
       "version": "0.26.1",
@@ -16449,15 +16197,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/spots": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/spots/-/spots-0.4.0.tgz",
-      "integrity": "sha512-WugtpL4zoap6ZE2VWKZTMfmhEE32jSHYHdbzoMbaXjgLmbE0aUnEErIzpyeb3JyfW8HLmcfcCCIjK1jrdTRg1Q==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -16697,22 +16436,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stop-build": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stop-build/-/stop-build-1.1.0.tgz",
-      "integrity": "sha512-RKkSh9/FY4YbK9Pbf5lbnTcjI3mpkgfBDuD0ZeL0N4DxdZCRA8TVEuAlinbzoKcNBv+UtyPr1VekSybbuwUugg==",
-      "dev": true,
-      "dependencies": {
-        "ggit": "1.15.1",
-        "pluralize": "5.0.0"
-      },
-      "bin": {
-        "stop-build": "src/index.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/stream-combiner": {
@@ -17742,12 +17465,6 @@
       "engines": {
         "node": ">=8.0.0"
       }
-    },
-    "node_modules/weak-map": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
-      "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw==",
-      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -19523,12 +19240,6 @@
       "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
       "dev": true
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "dev": true
-    },
     "asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -19986,39 +19697,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
-    },
-    "chdir-promise": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.4.0.tgz",
-      "integrity": "sha512-fAvt/5sjLFKVp5bOc6FnMWB7kcXHk1uZSQa6tWdkkcT/Dv/hmsVwuabyDujd6G7a17mZipoYLJEaQcSEYrTG6Q==",
-      "dev": true,
-      "requires": {
-        "check-more-types": "2.23.0",
-        "debug": "^2.3.3",
-        "lazy-ass": "1.5.0",
-        "q": "1.1.2",
-        "spots": "0.4.0"
-      },
-      "dependencies": {
-        "check-more-types": {
-          "version": "2.23.0",
-          "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
-          "integrity": "sha512-dDo5EKT4pZj5GArqso+z2TJmk5/fb+MqtwqJO4IdVhmL9rjglTvndCTRRwxDlQT9FObaYJENljJ0A+8ckAYakQ==",
-          "dev": true
-        },
-        "lazy-ass": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
-          "integrity": "sha512-5l6J7+KWp/OiisiR/KkwuPgeaIyb8d5jlLZsncDpffa5aBtOCcEcyoXoMGxOw50fr7RrCxEGqXkIHGRl1PL7ig==",
-          "dev": true
-        },
-        "q": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-          "integrity": "sha512-ROtylwux7Vkc4C07oKE/ReigUmb33kVoLtcR4SJ1QVqwaZkBEDL3vX4/kwFzIERQ5PfCl0XafbU8u2YUhyGgVA==",
-          "dev": true
-        }
-      }
     },
     "check-more-types": {
       "version": "2.24.0",
@@ -20892,12 +20570,6 @@
           "dev": true
         }
       }
-    },
-    "d3-helpers": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/d3-helpers/-/d3-helpers-0.3.0.tgz",
-      "integrity": "sha512-uNJ5QRsTW7CdNC6CHX528VwIEzYCC/iFHMQ9ReaDUGA+iiJXHcR2uKobK68FkKSWmNYPxwaUV+9SswjoygF6VA==",
-      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
@@ -22344,122 +22016,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "ggit": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/ggit/-/ggit-1.15.1.tgz",
-      "integrity": "sha512-xfdO/qLRT2Xqv8sZgom726ZhWmBBjhTd6qKhEZ1LnRzAu14bN+qf+CGd/u1YJP0k18KEbC65gsW/pbKnNtOWzg==",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.5.0",
-        "chdir-promise": "0.4.0",
-        "check-more-types": "2.24.0",
-        "cli-table": "0.3.1",
-        "colors": "1.1.2",
-        "commander": "2.9.0",
-        "d3-helpers": "0.3.0",
-        "debug": "2.6.3",
-        "glob": "7.1.1",
-        "lazy-ass": "1.6.0",
-        "lodash": "3.10.1",
-        "moment": "2.18.1",
-        "optimist": "0.6.1",
-        "q": "2.0.3",
-        "quote": "0.4.0",
-        "ramda": "0.9.1"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha512-3LE8m8bqjGdoxfvf71yhFNrUcwy3NLy00SAo+b6MfJ8l+Bc2DzQ7mUHwX6pjK2AxfgV+YfsjCeVW3T5HLQTBsQ==",
-          "dev": true
-        },
-        "cli-table": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-          "integrity": "sha512-h/TzJrgwzVV+W6laITBZAxAWfBjX4T0x+LF5XJdS1AzDkXqmraMNnKQ/O/f3AHJKVR85fOglUEdS/B0P1wS7Aw==",
-          "dev": true,
-          "requires": {
-            "colors": "1.0.3"
-          },
-          "dependencies": {
-            "colors": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-              "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
-              "dev": true
-            }
-          }
-        },
-        "colors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "integrity": "sha512-ENwblkFQpqqia6b++zLD/KUWafYlVY/UNnAp7oz7LY7E924wmpye416wBOmvv/HMWzl8gL1kJlfvId/1Dg176w==",
-          "dev": true
-        },
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": ">= 1.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
-          "integrity": "sha512-9k275CFA9z/NW+7nojeyxyOCFYsc+Dfiq4Sg8CBP5WjzmJT5K1utEepahY7wuWhlsumHgmAqnwAnxPCgOOyAHA==",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "glob": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha512-mRyN/EsN2SyNhKWykF3eEGhDpeNplMWaW18Bmh76tnOqk5TbELAVwFAYOCmKVssOYFrYvvLMguiA+NXO3ZTuVA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.2",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha512-5NnE67nQSQDJHVahPJna1PQ/zCXMnQop3yUCxjKPNzCxuyPSKWTQ/5Gu5CZmjetwGLWRA+PzeF5thlbOdbQldA==",
-          "dev": true
-        },
-        "q": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/q/-/q-2.0.3.tgz",
-          "integrity": "sha512-gv6vLGcmAOg96/fgo3d9tvA4dJNZL3fMyBqVRrGxQ+Q/o4k9QzbJ3NQF9cOO/71wRodoXhaPgphvMFU68qVAJQ==",
-          "dev": true,
-          "requires": {
-            "asap": "^2.0.0",
-            "pop-iterate": "^1.0.1",
-            "weak-map": "^1.0.5"
-          }
-        },
-        "ramda": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.9.1.tgz",
-          "integrity": "sha512-Rccpyj5OM4v2ecM8Ej0canQkH4FSAu9o+mZezRl20/Uph1B1deJ26NjevZH4v7E0ngANvbKw7azX1a8v6KoBrQ==",
-          "dev": true
-        }
-      }
-    },
     "git-hooks-list": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-1.0.3.tgz",
@@ -22806,12 +22362,6 @@
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
-      "dev": true
     },
     "handlebars": {
       "version": "4.7.7",
@@ -25075,12 +24625,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
-      "dev": true
-    },
-    "moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha512-QGcnVKRSEhbWy2i0pqFhjWMCczL/YU5ICMB3maUavFcyUqBszRnzsswvOaGOqSfWZ/R+dMnb9gGBuRT4LMTdVQ==",
       "dev": true
     },
     "morgan": {
@@ -29095,30 +28639,6 @@
         "is-wsl": "^2.1.1"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-          "dev": true
-        }
-      }
-    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -29457,18 +28977,6 @@
         "semver-compare": "^1.0.0"
       }
     },
-    "pluralize": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-5.0.0.tgz",
-      "integrity": "sha512-3XyqUZZQZhBf6vt9FP49WhY+ZeqYT7Y6pWn4uWCAifD5tganssOlrsLbMysFM1Rgnmd9k2OUsgvDe7jWSXrchQ==",
-      "dev": true
-    },
-    "pop-iterate": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pop-iterate/-/pop-iterate-1.0.1.tgz",
-      "integrity": "sha512-HRCx4+KJE30JhX84wBN4+vja9bNfysxg1y28l0DuJmkoaICiv2ZSilKddbS48pq50P8d2erAhqDLbp47yv3MbQ==",
-      "dev": true
-    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -29654,12 +29162,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "dev": true
-    },
-    "quote": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
-      "integrity": "sha512-KHp3y3xDjuBhRx+tYKOgzPnVHMRlgpn2rU450GcU4PL24r1H6ls/hfPrxDwX2pvYMlwODHI2l8WwgoV69x5rUQ==",
       "dev": true
     },
     "ramda": {
@@ -30942,12 +30444,6 @@
         }
       }
     },
-    "spots": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/spots/-/spots-0.4.0.tgz",
-      "integrity": "sha512-WugtpL4zoap6ZE2VWKZTMfmhEE32jSHYHdbzoMbaXjgLmbE0aUnEErIzpyeb3JyfW8HLmcfcCCIjK1jrdTRg1Q==",
-      "dev": true
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -31124,16 +30620,6 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
       "dev": true
-    },
-    "stop-build": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stop-build/-/stop-build-1.1.0.tgz",
-      "integrity": "sha512-RKkSh9/FY4YbK9Pbf5lbnTcjI3mpkgfBDuD0ZeL0N4DxdZCRA8TVEuAlinbzoKcNBv+UtyPr1VekSybbuwUugg==",
-      "dev": true,
-      "requires": {
-        "ggit": "1.15.1",
-        "pluralize": "5.0.0"
-      }
     },
     "stream-combiner": {
       "version": "0.0.4",
@@ -31953,12 +31439,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-4.0.0.tgz",
       "integrity": "sha512-kudCA8PXVQfrqv2mFTG72vDBRi8BKWxGgFLwPpzHcpZnSwZk93WMwUDVcLHWNsnm+Y0AC4Vb6MUNRgaHfyV2DQ==",
-      "dev": true
-    },
-    "weak-map": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
-      "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw==",
       "dev": true
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "netlify-plugin-cypress": "2.0.0",
     "semantic-release": "15.13.32",
     "start-server-and-test": "1.10.11",
-    "stop-build": "1.1.0",
     "yaml-lint": "1.2.4"
   },
   "engines": {


### PR DESCRIPTION
This PR removes the unused npm package [stop-build](https://www.npmjs.com/package/stop-build) which invokes critical vulnerabilities in `npm audit` through `minimist@0.0.10` and `lodash@3.10.1`. The package was last updated 6 years ago and it appears to be unmaintainable due to its own dependencies (see https://github.com/bahmutov/stop-build/issues/3).

After this change `npm audit` reports:

`41 vulnerabilities (1 low, 7 moderate, 33 high)`
