### PR TITLE
chore(deps): use ubuntu-22.04 in gh workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,7 +3,7 @@ name: Code analysis
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     name: check tests
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/chrome-headless.yml
+++ b/.github/workflows/chrome-headless.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   chrome-headless:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/chrome.yml
+++ b/.github/workflows/chrome.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   chrome:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -8,7 +8,7 @@ on: push
 jobs:
   install:
     name: Install NPM and Cypress
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
@@ -73,7 +73,7 @@ jobs:
   # anchor definitions yet, thus we cannot put same steps into a template object yet
   test1:
     name: Cypress test 1
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs: install
     steps:
       - uses: actions/checkout@v3
@@ -137,7 +137,7 @@ jobs:
 
   test2:
     name: Cypress test 2
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs: install
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -7,7 +7,7 @@ on: push
 jobs:
   test1:
     name: Cypress test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -6,7 +6,7 @@ on: push
 
 jobs:
   single-run:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -19,7 +19,7 @@ jobs:
 
   parallel-runs:
     name: Parallel 4x
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       # when one test fails, DO NOT cancel the other
       # containers, because this will kill Cypress processes
@@ -60,7 +60,7 @@ jobs:
       matrix:
         # run 2 copies of the current job in parallel
         # and they will load balance all specs
-        os: ['ubuntu-18.04', 'windows-latest', 'macos-latest']
+        os: ['ubuntu-22.04', 'windows-latest', 'macos-latest']
         machines: [1, 2]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can verify this by opening your browser and navigating to: [`http://localhos
 You should see the Kitchen Sink App up and running. We are now ready to run Cypress tests.
 
 ```bash
-## launch the cypress test runner
+# launch the cypress test runner
 npm run cy:open
 ```
 


### PR DESCRIPTION
This PR updates workflows in [.github/workflows](https://github.com/cypress-io/cypress-example-kitchensink/tree/master/.github/workflows) which are currently specifying `ubuntu-18.04`.

According to [ubuntu-18.04 README](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu1804-Readme.md) this version is deprecated and will be fully unsupported by April 1, 2023.

The affected workflows are updated to use [ubuntu-22.04](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md) instead, which is currently equivalent to `ubuntu-latest`.