### PR TITLE
fix: remove unreachable CI provider "Shippable"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Heroku CI | | [basic/app.json](basic/app.json) |
 Jenkins | | [basic/Jenkinsfile](basic/Jenkinsfile) | [Jenkinsfile](Jenkinsfile)
 Netlify | [![Netlify Status](https://api.netlify.com/api/v1/badges/016bd76b-ebfd-4071-94d9-8668afbb56f7/deploy-status)](https://app.netlify.com/sites/cypress-example-kitchensink/deploys) | [netlify.toml](netlify.toml) |
 Semaphore v2 | [![Project dashboard](https://cypress-io.semaphoreci.com/badges/cypress-example-kitchensink/branches/master.svg)](https://cypress-io.semaphoreci.com/projects/cypress-example-kitchensink) | [basic/.semaphore.yml](basic/.semaphore.yml) | [.semaphore/semaphore.yml](.semaphore/semaphore.yml)
-Shippable | [![Shippable CI](https://api.shippable.com/projects/56c38fdc1895ca4474743010/badge?branch=master)](https://app.shippable.com/github/cypress-io/cypress-example-kitchensink) | [shippable.yml](shippable.yml)
 Travis | [![Travis CI](https://travis-ci.org/cypress-io/cypress-example-kitchensink.svg?branch=master)](https://travis-ci.org/cypress-io/cypress-example-kitchensink) | [basic/.travis.yml](basic/.travis.yml) | [.travis.yml](.travis.yml)
 
 You can find all CI results recorded on the [![Cypress Dashboard](https://img.shields.io/badge/cypress-dashboard-brightgreen.svg)](https://dashboard.cypress.io/#/projects/4b7344/runs)


### PR DESCRIPTION
This PR removes the obsolete CI provider "Shippable" from being displayed in [README.md](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/README.md). No CI results can be displayed from "Shippable" since it is no longer operating.

## Background

The former CI provider "Shippable" no longer provides a service.

- https://app.shippable.com/github/cypress-io/cypress-example-kitchensink is no longer reachable.
- http://docs.shippable.com/ is no longer reachable.
- The badge `[![Shippable CI](https://api.shippable.com/projects/56c38fdc1895ca4474743010/badge?branch=master)](https://app.shippable.com/github/cypress-io/cypress-example-kitchensink)` no longer responds.
- Shippable's GitHub repositories under https://github.com/Shippable have not been updated since September 2021.

- See [We’ve Acquired Shippable to Complete DevOps Pipeline Automation From Code to Production](https://jfrog.com/blog/weve-acquired-shippable-to-complete-devops-pipeline-automation-from-code-to-production/) February 21, 2019. JFrog stated they would replace shippable with [JFrog Pipelines](https://www.jfrog.com/confluence/display/JFROG/JFrog+Pipelines) however it seems there is no simple migration from a `Shippable` workflow to a `JFrog Pipelines` workflow. `JFrog Pipelines` would have to be treated like a completely new CI provider.

## Further suggested fixes

1. Remove the reference to [shippable.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/shippable.yml) in [Cypress documentation: CI Provider Examples](https://docs.cypress.io/guides/continuous-integration/ci-provider-examples#Shippable) - https://github.com/cypress-io/cypress-documentation/pull/5145
2. Remove the workflow [shippable.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/shippable.yml) from this repository

## Follow-on suggested (breaking) changes

After implementing the previous suggestions, the next steps would be:

1. Remove the orphaned workaround for issue https://github.com/cypress-io/cypress/issues/6718 from [cypress/e2e/2-advanced-examples/misc.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/2-advanced-examples/misc.cy.js) in this repository and merge into Cypress
2. Remove the support for "Shippable" as CI provider from [Core Cypress](https://github.com/cypress-io/cypress)

Removing functionality is a breaking change, even though it should theoretically have no practical impact, since "Shippable" is no longer operating. This would probably need to wait until a future suitable major release of Cypress is planned.