### PR TITLE
chore: fix releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
     executor: cypress/default
     steps:
       - checkout
-      - run: npx semantic-release --dry-run
+      - run: npx semantic-release@15.13.32 --dry-run
 
 workflows:
   win-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
     executor: cypress/default
     steps:
       - checkout
-      - run: npx run semantic-release --dry-run
+      - run: npx semantic-release --dry-run
 
 workflows:
   win-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,13 +158,11 @@ jobs:
           start-command: 'npm run start'
           cypress-command: 'npx cypress run --record --group Mac build'
 
-
   release:
     executor: cypress/default
     steps:
-      - attach_workspace:
-          at: ~/
-      - run: npm run semantic-release
+      - checkout
+      - run: npx run semantic-release --dry-run
 
 workflows:
   win-build:
@@ -201,7 +199,6 @@ workflows:
             - run: npx cypress version --component electron
             - run: npx cypress version --component node
     
-
       # run on 2 machines using Chrome browser
       - cypress/run:
           name: '2 machines using Chrome'
@@ -222,6 +219,7 @@ workflows:
             branches:
               only:
                 - master
+                - fix-releases
           requires:
             - 3 machines
             - 2 machines using Chrome

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
     executor: cypress/default
     steps:
       - checkout
-      - run: npx semantic-release@15.13.32 --dry-run
+      - run: npx semantic-release@15.13.32
 
 workflows:
   win-build:
@@ -219,7 +219,6 @@ workflows:
             branches:
               only:
                 - master
-                - fix-releases
           requires:
             - 3 machines
             - 2 machines using Chrome


### PR DESCRIPTION
- Closes #606 

This [job](https://app.circleci.com/pipelines/github/cypress-io/cypress-example-kitchensink/1279/workflows/16d803e2-23ea-4d29-af95-3cfd104d1a68/jobs/8671) demonstrates this working with `--dry-run`.