### PR TITLE
fix: migrate test checks to cypress 10+ location

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,6 +12,6 @@ jobs:
     - uses: testomatio/check-tests@stable
       with:
         framework: cypress
-        tests: "./cypress/integration/**/**.spec.js"
+        tests: "./cypress/e2e/**/**.cy.js"
         token: ${{ secrets.GITHUB_TOKEN }}
         has-tests-label: true


### PR DESCRIPTION
This PR fixes the workflow [.github/workflows/checks.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/checks.yml) which currently is looking in the wrong place for Cypress tests due to migration to Cypress 10.

## Issue

The workflow [.github/workflows/checks.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/checks.yml) finds no tests:

```test
Run testomatio/check-tests@stable
  with:
    framework: cypress
    tests: ./cypress/integration/**/**.spec.js
    token: ***
    has-tests-label: true
Using default branch master
Added 0 tests, removed 0 tests
Total 0 tests
```

## Analysis

The workflow is looking in the directory for a Cypress legacy configuration. This was changed through PR https://github.com/cypress-io/cypress-example-kitchensink/pull/528 in June 2022.

The test files have been renamed and relocated to `./cypress/e2e/**/**.cy.js`.

## Resolution

Correct the pathname to use `./cypress/e2e/**/**.cy.js`.