### PR TITLE
fix: single workflow syntax error

### DIFF
--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -60,7 +60,7 @@ jobs:
         npx cypress version --component node
 
     # Starts local server, then runs Cypress tests and records results on the dashboard
-    - name: Cypress tests
+    - name: Cypress single tests
       run: npm run test:ci:record
       env:
         # place your secret record key at
@@ -71,13 +71,13 @@ jobs:
     # Save videos and screenshots as test artifacts
     # https://github.com/actions/upload-artifact
     - uses: actions/upload-artifact@v3
-      with:
-        name: screenshots
-        path: cypress/screenshots
         # there might be no screenshots created when:
         # - there are no test failures
         # so only upload screenshots if previous step has failed
-        if: failure()
+      if: failure()
+      with:
+        name: screenshots
+        path: cypress/screenshots
     # video should always be generated
     - uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
This PR fixes a syntax error in [.github/workflows/single.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/single.yml).

## Issue

Running the workflow [.github/workflows/single.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/single.yml) causes a GitHub warning "Unexpected input(s) 'if', valid inputs are ['name', 'path', 'if-no-files-found', 'retention-days']".

## Analysis

The `if: failure()` statement should be before `with:`

https://github.com/cypress-io/cypress-example-kitchensink/blob/075d90df1b93dd45a6298c46f9325adf1cdb37fb/.github/workflows/single.yml#L73-L80

## Changes

1. Move the `if: failure()` statement to the right place, before `with:`.
2. Change the name of the workflow to "Cypress single tests" to
    - show that it is a counterpart to the workflow [Cypress parallel tests](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/parallel.yml)
    - differentiate it from the example workflow in the Cypress Documentation [Continuous Integration > GitHub Actions > Basic Setup](https://docs.cypress.io/guides/continuous-integration/github-actions#Basic-Setup) which uses `name: Cypress Tests`
