### PR TITLE
chore(deps): update CI Docker usage to cypress/base:18.14.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ cache:
 
 # this job installs NPM dependencies and Cypress
 install:
-  image: cypress/base:latest
+  image: cypress/base:18.14.1
   stage: build
 
   script:
@@ -35,7 +35,7 @@ install:
 
 # all jobs that actually run tests can use the same definition
 .job_template:
-  image: cypress/base:10
+  image: cypress/base:18.14.1
   stage: test
   script:
     # print CI environment variables for reference

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://documentation.codeship.com/pro/languages-frameworks/nodejs/
 
 # use Cypress provided image with all dependencies included
-FROM cypress/base:10
+FROM cypress/base:18.14.1
 RUN node --version
 RUN npm --version
 WORKDIR /home/node/app

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
   agent {
     // this image provides everything needed to run Cypress
     docker {
-      image 'cypress/base:10'
+      image 'cypress/base:18.14.1'
     }
   }
 

--- a/basic/.circleci/config.yml
+++ b/basic/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: cypress/base:latest
+      - image: cypress/base:18.14.1
     steps:
       - checkout
       # restore folders with npm dependencies and Cypress binary

--- a/basic/.gitlab-ci.yml
+++ b/basic/.gitlab-ci.yml
@@ -13,7 +13,7 @@ cache:
     - cache/Cypress
 
 test:
-  image: cypress/base:latest
+  image: cypress/base:18.14.1
   stage: test
   script:
     - npm ci

--- a/basic/Jenkinsfile
+++ b/basic/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
   agent {
     // this image provides everything needed to run Cypress
     docker {
-      image 'cypress/base:latest'
+      image 'cypress/base:18.14.1'
     }
   }
 

--- a/basic/codeship-pro/Dockerfile
+++ b/basic/codeship-pro/Dockerfile
@@ -2,7 +2,7 @@
 # https://documentation.codeship.com/pro/languages-frameworks/nodejs/
 
 # use Cypress provided image with all dependencies included
-FROM cypress/base:latest
+FROM cypress/base:18.14.1
 RUN node --version
 RUN npm --version
 WORKDIR /home/node/app

--- a/buddy.yml
+++ b/buddy.yml
@@ -8,7 +8,7 @@
       type: "BUILD"
       working_directory: "/buddy/cypress-example-kitchensink"
       docker_image_name: "cypress/base"
-      docker_image_tag: "latest"
+      docker_image_tag: "18.14.1"
       execute_commands:
         - "npm install --force"
         - "npm run cy:verify"


### PR DESCRIPTION
This PR updates each of the CI examples that were previously using the outdated Docker containers with Node.js versions 10 and 12, which already reached their respective [end-of-life](https://github.com/nodejs/release#release-schedule) on April 30, 2021 and April 30, 2022:

- `cypress/base:10`
- `cypress/base:latest`

The following examples are changed to use [cypress/base:18.14.1](https://hub.docker.com/layers/cypress/base/18.14.1/images/sha256-a63a2bec81efa794970664ad24466c1627138b8668d37f6cd22fd71f6080caad)

CI | Build status | basic config file | full parallel config
:--- | :--- | :--- | :---
[Buddy](https://buddy.works/docs) | - | [buddy.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/buddy.yml)
[CircleCI](https://circleci.com/docs/) | [![CircleCI](https://circleci.com/gh/cypress-io/cypress-example-kitchensink/tree/master.svg?style=svg)](https://circleci.com/gh/cypress-io/cypress-example-kitchensink/tree/master) | [basic/.circleci/config.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/basic/.circleci/config.yml) | [.circleci/config.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.circleci/config.yml)
[CloudBees CodeShip Pro](https://docs.cloudbees.com/docs/cloudbees-codeship) | - | [basic/codeship-pro](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/basic/codeship-pro)
[GitLab](https://docs.gitlab.com/ee/) | [![GitLab CI](https://gitlab.com/cypress-io/cypress-example-kitchensink/badges/master/pipeline.svg)](https://gitlab.com/cypress-io/cypress-example-kitchensink/commits/master) | [basic/.gitlab-ci.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/basic/.gitlab-ci.yml) | [.gitlab-ci.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.gitlab-ci.yml)
[Jenkins Pipeline](https://jenkins.io/doc/book/pipeline/) | - | [basic/Jenkinsfile](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/basic/Jenkinsfile) | [Jenkinsfile](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/Jenkinsfile)

## Background

- [cypress-io/cypress-example-kitchensink](https://github.com/cypress-io/cypress-example-kitchensink) is no longer compatible with Node.js 10. If `npm install` is executed under Node.js 12 or 14 it shows lockfile compatibility warnings. `npm install` completes with no lockfile warnings on Node.js 16 and 18 (current LTS).

- Note that [cypress/base:latest](https://hub.docker.com/layers/cypress/base/latest/images/sha256-81b8d9a8fc65c021e27852ca34196c745e7c0d24e56c63b211546179d3f7189a) is not what it looks like. It is configured to use Node.js `12.18.3`. See also https://github.com/cypress-io/cypress-docker-images/issues/876. Node.js 12 reached [end-of-life](https://github.com/nodejs/release#release-schedule) on April 30, 2022.

## Verification

### CircleCI

- [CircleCI](https://app.circleci.com/pipelines/github/cypress-io/cypress-example-kitchensink) is verified through https://app.circleci.com/pipelines/github/cypress-io/cypress-example-kitchensink which is triggered by any commit pushed to the `master` branch.

### GitLab

- [GitLab](https://gitlab.com/cypress-io/cypress-example-kitchensink/):  This PR is a partial resolution of issue #573. It can only be verified if it is pushed to GitLab. The GitHub repository is currently **not** being mirrored to GitLab.

### Non-verifiable

The following examples are not automatically verifiable. There is no build status listed in the [README: CI Status](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/README.md#ci-status) table for these CI providers:

- [Buddy](https://buddy.works/)
- [CloudBees CodeShip Pro](https://docs.cloudbees.com/docs/cloudbees-codeship/latest/pro-languages-frameworks/nodejs)
- [Jenkins Pipeline](https://jenkins.io/doc/book/pipeline/)

The examples have documentary status only. They are not live examples.
