### PR TITLE
chore(deps): update appveyor to node.js 18

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ skip_commits:
 # https://www.appveyor.com/docs/lang/nodejs-iojs/
 # Test against the latest version of this Node.js version
 environment:
-  nodejs_version: "12"
+  nodejs_version: "18"
 
 # Install scripts. (runs after repo cloning)
 install:


### PR DESCRIPTION
This PR updates the CI workflow [appveyor.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/appveyor.yml) from Node.js 12 to Node.js 18. The [Node.js release schedule](https://github.com/nodejs/release#release-schedule) shows that Node.js 12 already entered its end-of-life phase one year ago on April 30, 2022.

## Verification

Verify by inspection of

https://ci.appveyor.com/project/cypress-io/cypress-example-kitchensink