### PR TITLE
chore(deps): update CI Chrome Docker example to Docker Node.js 18

### DIFF
--- a/.github/workflows/chrome-docker.yml
+++ b/.github/workflows/chrome-docker.yml
@@ -5,9 +5,9 @@ on: push
 jobs:
   # run Chrome inside a Docker container
   chrome:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # https://github.com/cypress-io/cypress-docker-images
-    container: cypress/browsers:node14.17.6-chrome100-ff98
+    container: cypress/browsers:node18.12.0-chrome107
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR updates the CI example [.github/workflows/chrome-docker.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/chrome-docker.yml).

1. It binds the workflow to `ubuntu-22.04` instead of `ubuntu-latest` in alignment with other workflows contained in the [.github/workflows](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows) directory.
2. It updates the Docker container from
    - [cypress/browsers:node14.17.6-chrome100-ff98](https://hub.docker.com/layers/cypress/browsers/node14.17.6-chrome100-ff98/images/sha256-3f1ceb98712c697071ac194a0cae263a8b082af8ed418b7792dd9b0888a0338f) to
    - [cypress/browsers:node18.12.0-chrome107](https://hub.docker.com/layers/cypress/browsers/node18.12.0-chrome107/images/sha256-50959d1166a52276536e5535d1671692b83c097921685fe6a17f020d0b0f6ccf)

 Node.js 14 is scheduled for [end-of-life (EOL)](https://github.com/nodejs/release#release-schedule) in three weeks' time on April 30, 2023. Node.js 18 EOL is not until 2025.

## Verification

View action log on https://github.com/cypress-io/cypress-example-kitchensink/actions/workflows/chrome-docker.yml
