### PR TITLE
chore(deps): update CI GitHub single and parallel to Node.js 18

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -1,6 +1,9 @@
 # GitHub Actions
-# https://help.github.com/en/articles/configuring-a-workflow
-# good list of examples at http://www.thedreaming.org/2019/09/10/github-ci/
+# https://docs.github.com/en/actions/using-workflows
+# See also .github/workflows/using-action.yml in this repository
+# for an example of using the Cypress GitHub JavaScript action
+# https://github.com/cypress-io/github-action
+#
 name: Cypress parallel tests
 
 on: push
@@ -14,10 +17,10 @@ jobs:
 
       # install a specific version of Node using
       # https://github.com/actions/setup-node
-      - name: Use Node.js v14
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
 
       # just so we learn about available environment variables GitHub provides
       - name: Print CI env variables
@@ -80,10 +83,10 @@ jobs:
 
       # install a specific version of Node using
       # https://github.com/actions/setup-node
-      - name: Use Node.js v14
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
 
       # Restore just local node_modules and the Cypress binary archives.
       - name: Cache Cypress binary
@@ -108,7 +111,7 @@ jobs:
           npx cypress cache path
           npx cypress cache list
 
-      # Starts local server, then runs Cypress tests and records results on the dashboard
+      # Starts local server, then runs Cypress tests and records results on Cypress Cloud
       - name: Cypress tests
         run: |
           npm start &
@@ -144,10 +147,10 @@ jobs:
 
       # install a specific version of Node using
       # https://github.com/actions/setup-node
-      - name: Use Node.js v14
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
 
       # Restore just local node_modules and the Cypress binary archives.
       - name: Cache Cypress binary
@@ -172,7 +175,7 @@ jobs:
           npx cypress cache path
           npx cypress cache list
 
-      # Starts local server, then runs Cypress tests and records results on the dashboard
+      # Starts local server, then runs Cypress tests and records results on Cypress Cloud
       - name: Cypress tests
         run: |
           npm start &

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -1,6 +1,6 @@
 # GitHub Actions
-# https://help.github.com/en/articles/configuring-a-workflow
-name: Cypress tests
+# https://docs.github.com/en/actions/using-workflows
+name: Cypress single tests
 
 on: push
 
@@ -13,10 +13,10 @@ jobs:
 
     # install a specific version of Node using
     # https://github.com/actions/setup-node
-    - name: Use Node.js v14
+    - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
-        node-version: 14
+        node-version: 18
 
     # just so we learn about available environment variables GitHub provides
     - name: Print env variables
@@ -59,8 +59,8 @@ jobs:
         npx cypress version --component electron
         npx cypress version --component node
 
-    # Starts local server, then runs Cypress tests and records results on the dashboard
-    - name: Cypress single tests
+    # Starts local server, then runs Cypress tests and records results on Cypress Cloud
+    - name: Cypress tests
       run: npm run test:ci:record
       env:
         # place your secret record key at


### PR DESCRIPTION
This PR updates the CI examples

- [.github/workflows/single.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/single.yml)
- [.github/workflows/parallel.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/parallel.yml)

to use Node.js 18 instead of Node.js 14 (which has its [end-of-life transition](https://github.com/nodejs/release#release-schedule) in 3 weeks on April 30, 2023).

## Other changes

- Links have been updated.

- Dashboard is renamed to Cypress Cloud in comments.

- The link to outdated (2019) contents in http://www.thedreaming.org/2019/09/10/github-ci/ is removed and replaced by a reference to [.github/workflows/using-action.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/using-action.yml).

- The renaming of the single action to `name: Cypress single tests` is moved to the top of the action which was the intention in PR https://github.com/cypress-io/cypress-example-kitchensink/pull/610. Due to my mistake it was changed in the wrong place.  The goal was to have the name unambiguously shown in the [Actions](https://github.com/cypress-io/cypress-example-kitchensink/actions) list.

## Verification

See workflow results in

- https://github.com/cypress-io/cypress-example-kitchensink/actions/workflows/single.yml
- https://github.com/cypress-io/cypress-example-kitchensink/actions/workflows/parallel.yml
