### PR TITLE
chore(deps): update Heroku CI to heroku-22

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "stack": "cedar-14",
+  "stack": "heroku-22",
   "environments": {
     "test": {
       "buildpacks": [


### PR DESCRIPTION
This PR updates the [Heroku CI: app.json](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/basic/app.json) workflow to a supported version of Ubuntu.

The workflow is currently configured to use

`"stack": "cedar-14"` 

which selects Ubuntu 14.04 LTS. This stack entered (a postponed) [end-of-life](https://devcenter.heroku.com/changelog-items/1603) more than 2 years ago on November 2, 2020.

The `stack` is updated by this PR to 

`heroku-22`

as listed in [Upgrading to the Latest Stack](https://devcenter.heroku.com/articles/upgrading-to-the-latest-stack). This corresponds to Ubuntu 22.04 LTS.

## Verification

This example is not automatically verifiable. There is no build status listed in the [README: CI Status](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/README.md#ci-status) table for:

- [Heroku CI](https://devcenter.heroku.com/articles/heroku-ci)

This is a documentation-only example, not a live example.