### PR TITLE
fix: restore set-port.js to work in Cypress 10+ environment

### DIFF
--- a/scripts/set-port.js
+++ b/scripts/set-port.js
@@ -8,7 +8,7 @@ const { readFileSync, writeFileSync } = require('fs')
 // in all our example specs and then run the tests
 
 // if doing it locally, you can change back to the original port
-// with "git checkout cypress/integration/examples" command
+// with "git restore ." command
 
 if (!process.env.PORT) {
   console.log('PORT environment variable is not set, nothing to do')
@@ -30,7 +30,7 @@ console.log('replacing "%s" with "%s" in all spec files', input, newUrl)
 const getSpecFilenames = () => {
   const globby = require('globby')
 
-  return globby(['cypress/integration/**/*.spec.js'])
+  return globby(['cypress/e2e/**/*.cy.js'])
 }
 
 const replacePort = (filename) => {
@@ -48,4 +48,3 @@ getSpecFilenames()
     console.error(e.message)
     process.exit(1)
   })
-


### PR DESCRIPTION
This PR restores [scripts/set-port.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/scripts/set-port.js) to a working condition after the migration of examples from `cypress/integration` to [cypress/e2e](https://github.com/cypress-io/cypress-example-kitchensink/tree/master/cypress/e2e) in PR #528.

[scripts/set-port.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/scripts/set-port.js) is only used by the workflow [app.json](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/app.json) which is a documentation-only example for the [Heroku CI](https://devcenter.heroku.com/articles/heroku-ci) provider. The workflow calls it through `npm run ci:set-port`

Since this is not a live example and there is no status badge, the issue was not previously noticed and reported.

## Verification

```bash
export PORT=3000
npm run ci:set-port
```
expect output like this:

```text
> cypress-example-kitchensink@0.0.0-development ci:set-port
> node ./scripts/set-port

replacing "localhost:8080" with "localhost:3000" in all spec files
```

then

```bash
git status
```

should show 20 changed files:

```text
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   cypress/e2e/1-getting-started/todo.cy.js
        modified:   cypress/e2e/2-advanced-examples/actions.cy.js
        modified:   cypress/e2e/2-advanced-examples/aliasing.cy.js
        modified:   cypress/e2e/2-advanced-examples/assertions.cy.js
        modified:   cypress/e2e/2-advanced-examples/connectors.cy.js
        modified:   cypress/e2e/2-advanced-examples/cookies.cy.js
        modified:   cypress/e2e/2-advanced-examples/cypress_api.cy.js
        modified:   cypress/e2e/2-advanced-examples/files.cy.js
        modified:   cypress/e2e/2-advanced-examples/location.cy.js
        modified:   cypress/e2e/2-advanced-examples/misc.cy.js
        modified:   cypress/e2e/2-advanced-examples/navigation.cy.js
        modified:   cypress/e2e/2-advanced-examples/network_requests.cy.js
        modified:   cypress/e2e/2-advanced-examples/querying.cy.js
        modified:   cypress/e2e/2-advanced-examples/spies_stubs_clocks.cy.js
        modified:   cypress/e2e/2-advanced-examples/storage.cy.js
        modified:   cypress/e2e/2-advanced-examples/traversal.cy.js
        modified:   cypress/e2e/2-advanced-examples/utilities.cy.js
        modified:   cypress/e2e/2-advanced-examples/viewport.cy.js
        modified:   cypress/e2e/2-advanced-examples/waiting.cy.js
        modified:   cypress/e2e/2-advanced-examples/window.cy.js

no changes added to commit (use "git add" and/or "git commit -a")
```

then execute

```bash
git restore .
```

to revert the changes.