### PR TITLE
docs: remove Travis CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Heroku CI | | [basic/app.json](basic/app.json) |
 Jenkins | | [basic/Jenkinsfile](basic/Jenkinsfile) | [Jenkinsfile](Jenkinsfile)
 Netlify | [![Netlify Status](https://api.netlify.com/api/v1/badges/016bd76b-ebfd-4071-94d9-8668afbb56f7/deploy-status)](https://app.netlify.com/sites/cypress-example-kitchensink/deploys) | [netlify.toml](netlify.toml) |
 Semaphore v2 | [![Project dashboard](https://cypress-io.semaphoreci.com/badges/cypress-example-kitchensink/branches/master.svg)](https://cypress-io.semaphoreci.com/projects/cypress-example-kitchensink) | [basic/.semaphore.yml](basic/.semaphore.yml) | [.semaphore/semaphore.yml](.semaphore/semaphore.yml)
-Travis | [![Travis CI](https://travis-ci.org/cypress-io/cypress-example-kitchensink.svg?branch=master)](https://travis-ci.org/cypress-io/cypress-example-kitchensink) | [basic/.travis.yml](basic/.travis.yml) | [.travis.yml](.travis.yml)
+Travis | | [basic/.travis.yml](basic/.travis.yml) | [.travis.yml](.travis.yml)
 
 You can find all CI results recorded on the [![Cypress Dashboard](https://img.shields.io/badge/cypress-dashboard-brightgreen.svg)](https://dashboard.cypress.io/#/projects/4b7344/runs)
 


### PR DESCRIPTION
This PR resolves https://github.com/cypress-io/cypress-example-kitchensink/issues/602. It removes the failing status badge for Travis CI from the [CI Status table](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/README.md#ci-status).

The links to Travis CI workflows can remain. They may be useful as templates for users of Travis CI who have migrated to the subscription service. More than half of the examples in this table are documentation-only examples which do not demonstrate any live CI run and status, so leaving the Travis CI workflows in the table would fit into this structure.