### PR TITLE
chore: remove husky hooks from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,11 +77,5 @@
   },
   "engines": {
     "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run lint && npm run lint:yaml",
-      "pre-push": "npm run lint && npm run lint:yaml"
-    }
   }
 }


### PR DESCRIPTION
This PR removes the `v1` Husky hooks located in [package.json](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/package.json). These were replaced by [.husky/pre-commit](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.husky/pre-commit) through PR https://github.com/cypress-io/cypress-example-kitchensink/pull/626.

The `v1` Husky hooks are unused by Husky `v8`.

See Husky documentation [Migrate from v4 to v8](https://typicode.github.io/husky/#/?id=migrate-from-v4-to-v8).