### PR TITLE
chore: add cypress/downloads to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 *.log
 *.aes
+cypress/downloads
 cypress/screenshots
 cypress/videos
 cypress/logs


### PR DESCRIPTION
This PR adds the `cypress/downloads` directory to [.gitignore](https://github.com/cypress-io/github-action/blob/master/.gitignore). See Cypress documentation [Configuration: Folders/Files](https://docs.cypress.io/guides/references/configuration#Folders--Files).

This is a temporary directory and its contents should not be committed to git.