### PR TITLE
feat: update example tests for compatibility with latest recommended mocha lint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
   },
   "rules": {
     "indent": ["error", 2, { "SwitchCase": 1, "MemberExpression": "off" }],
-    "mocha/no-exclusive-tests": "error"
+    "mocha/no-exclusive-tests": "error",
+    "mocha/no-mocha-arrows": "off"
   }
 }

--- a/cypress/e2e/2-advanced-examples/cypress_api.cy.js
+++ b/cypress/e2e/2-advanced-examples/cypress_api.cy.js
@@ -1,184 +1,187 @@
 /// <reference types="cypress" />
 
-context('Cypress.Commands', () => {
-  beforeEach(() => {
-    cy.visit('http://localhost:8080/cypress-api')
-  })
+context('Cypress APIs', () => {
 
-  // https://on.cypress.io/custom-commands
+  context('Cypress.Commands', () => {
+    beforeEach(() => {
+      cy.visit('http://localhost:8080/cypress-api')
+    })
 
-  it('.add() - create a custom command', () => {
-    Cypress.Commands.add('console', {
-      prevSubject: true,
-    }, (subject, method) => {
+    // https://on.cypress.io/custom-commands
+
+    it('.add() - create a custom command', () => {
+      Cypress.Commands.add('console', {
+        prevSubject: true,
+      }, (subject, method) => {
       // the previous subject is automatically received
       // and the commands arguments are shifted
 
-      // allow us to change the console method used
-      method = method || 'log'
+        // allow us to change the console method used
+        method = method || 'log'
 
-      // log the subject to the console
-      // eslint-disable-next-line no-console
-      console[method]('The subject is', subject)
+        // log the subject to the console
+        // eslint-disable-next-line no-console
+        console[method]('The subject is', subject)
 
-      // whatever we return becomes the new subject
-      // we don't want to change the subject so
-      // we return whatever was passed in
-      return subject
-    })
+        // whatever we return becomes the new subject
+        // we don't want to change the subject so
+        // we return whatever was passed in
+        return subject
+      })
 
-    // eslint-disable-next-line no-unused-vars
-    cy.get('button').console('info').then(($button) => {
+      // eslint-disable-next-line no-unused-vars
+      cy.get('button').console('info').then(($button) => {
       // subject is still $button
+      })
     })
   })
-})
 
-context('Cypress.Cookies', () => {
-  beforeEach(() => {
-    cy.visit('http://localhost:8080/cypress-api')
+  context('Cypress.Cookies', () => {
+    beforeEach(() => {
+      cy.visit('http://localhost:8080/cypress-api')
+    })
+
+    // https://on.cypress.io/cookies
+    it('.debug() - enable or disable debugging', () => {
+      Cypress.Cookies.debug(true)
+
+      // Cypress will now log in the console when
+      // cookies are set or cleared
+      cy.setCookie('fakeCookie', '123ABC')
+      cy.clearCookie('fakeCookie')
+      cy.setCookie('fakeCookie', '123ABC')
+      cy.clearCookie('fakeCookie')
+      cy.setCookie('fakeCookie', '123ABC')
+    })
   })
 
-  // https://on.cypress.io/cookies
-  it('.debug() - enable or disable debugging', () => {
-    Cypress.Cookies.debug(true)
+  context('Cypress.arch', () => {
+    beforeEach(() => {
+      cy.visit('http://localhost:8080/cypress-api')
+    })
 
-    // Cypress will now log in the console when
-    // cookies are set or cleared
-    cy.setCookie('fakeCookie', '123ABC')
-    cy.clearCookie('fakeCookie')
-    cy.setCookie('fakeCookie', '123ABC')
-    cy.clearCookie('fakeCookie')
-    cy.setCookie('fakeCookie', '123ABC')
-  })
-})
-
-context('Cypress.arch', () => {
-  beforeEach(() => {
-    cy.visit('http://localhost:8080/cypress-api')
-  })
-
-  it('Get CPU architecture name of underlying OS', () => {
+    it('Get CPU architecture name of underlying OS', () => {
     // https://on.cypress.io/arch
-    expect(Cypress.arch).to.exist
-  })
-})
-
-context('Cypress.config()', () => {
-  beforeEach(() => {
-    cy.visit('http://localhost:8080/cypress-api')
+      expect(Cypress.arch).to.exist
+    })
   })
 
-  it('Get and set configuration options', () => {
+  context('Cypress.config()', () => {
+    beforeEach(() => {
+      cy.visit('http://localhost:8080/cypress-api')
+    })
+
+    it('Get and set configuration options', () => {
     // https://on.cypress.io/config
-    let myConfig = Cypress.config()
+      let myConfig = Cypress.config()
 
-    expect(myConfig).to.have.property('animationDistanceThreshold', 5)
-    expect(myConfig).to.have.property('baseUrl', null)
-    expect(myConfig).to.have.property('defaultCommandTimeout', 4000)
-    expect(myConfig).to.have.property('requestTimeout', 5000)
-    expect(myConfig).to.have.property('responseTimeout', 30000)
-    expect(myConfig).to.have.property('viewportHeight', 660)
-    expect(myConfig).to.have.property('viewportWidth', 1000)
-    expect(myConfig).to.have.property('pageLoadTimeout', 60000)
-    expect(myConfig).to.have.property('waitForAnimations', true)
+      expect(myConfig).to.have.property('animationDistanceThreshold', 5)
+      expect(myConfig).to.have.property('baseUrl', null)
+      expect(myConfig).to.have.property('defaultCommandTimeout', 4000)
+      expect(myConfig).to.have.property('requestTimeout', 5000)
+      expect(myConfig).to.have.property('responseTimeout', 30000)
+      expect(myConfig).to.have.property('viewportHeight', 660)
+      expect(myConfig).to.have.property('viewportWidth', 1000)
+      expect(myConfig).to.have.property('pageLoadTimeout', 60000)
+      expect(myConfig).to.have.property('waitForAnimations', true)
 
-    expect(Cypress.config('pageLoadTimeout')).to.eq(60000)
+      expect(Cypress.config('pageLoadTimeout')).to.eq(60000)
 
-    // this will change the config for the rest of your tests!
-    Cypress.config('pageLoadTimeout', 20000)
+      // this will change the config for the rest of your tests!
+      Cypress.config('pageLoadTimeout', 20000)
 
-    expect(Cypress.config('pageLoadTimeout')).to.eq(20000)
+      expect(Cypress.config('pageLoadTimeout')).to.eq(20000)
 
-    Cypress.config('pageLoadTimeout', 60000)
-  })
-})
-
-context('Cypress.dom', () => {
-  beforeEach(() => {
-    cy.visit('http://localhost:8080/cypress-api')
+      Cypress.config('pageLoadTimeout', 60000)
+    })
   })
 
-  // https://on.cypress.io/dom
-  it('.isHidden() - determine if a DOM element is hidden', () => {
-    let hiddenP = Cypress.$('.dom-p p.hidden').get(0)
-    let visibleP = Cypress.$('.dom-p p.visible').get(0)
+  context('Cypress.dom', () => {
+    beforeEach(() => {
+      cy.visit('http://localhost:8080/cypress-api')
+    })
 
-    // our first paragraph has css class 'hidden'
-    expect(Cypress.dom.isHidden(hiddenP)).to.be.true
-    expect(Cypress.dom.isHidden(visibleP)).to.be.false
+    // https://on.cypress.io/dom
+    it('.isHidden() - determine if a DOM element is hidden', () => {
+      let hiddenP = Cypress.$('.dom-p p.hidden').get(0)
+      let visibleP = Cypress.$('.dom-p p.visible').get(0)
+
+      // our first paragraph has css class 'hidden'
+      expect(Cypress.dom.isHidden(hiddenP)).to.be.true
+      expect(Cypress.dom.isHidden(visibleP)).to.be.false
+    })
   })
-})
 
-context('Cypress.env()', () => {
-  beforeEach(() => {
-    cy.visit('http://localhost:8080/cypress-api')
-  })
+  context('Cypress.env()', () => {
+    beforeEach(() => {
+      cy.visit('http://localhost:8080/cypress-api')
+    })
 
-  // We can set environment variables for highly dynamic values
+    // We can set environment variables for highly dynamic values
 
-  // https://on.cypress.io/environment-variables
-  it('Get environment variables', () => {
+    // https://on.cypress.io/environment-variables
+    it('Get environment variables', () => {
     // https://on.cypress.io/env
     // set multiple environment variables
-    Cypress.env({
-      host: 'veronica.dev.local',
-      api_server: 'http://localhost:8888/v1/',
+      Cypress.env({
+        host: 'veronica.dev.local',
+        api_server: 'http://localhost:8888/v1/',
+      })
+
+      // get environment variable
+      expect(Cypress.env('host')).to.eq('veronica.dev.local')
+
+      // set environment variable
+      Cypress.env('api_server', 'http://localhost:8888/v2/')
+      expect(Cypress.env('api_server')).to.eq('http://localhost:8888/v2/')
+
+      // get all environment variable
+      expect(Cypress.env()).to.have.property('host', 'veronica.dev.local')
+      expect(Cypress.env()).to.have.property('api_server', 'http://localhost:8888/v2/')
+    })
+  })
+
+  context('Cypress.log', () => {
+    beforeEach(() => {
+      cy.visit('http://localhost:8080/cypress-api')
     })
 
-    // get environment variable
-    expect(Cypress.env('host')).to.eq('veronica.dev.local')
-
-    // set environment variable
-    Cypress.env('api_server', 'http://localhost:8888/v2/')
-    expect(Cypress.env('api_server')).to.eq('http://localhost:8888/v2/')
-
-    // get all environment variable
-    expect(Cypress.env()).to.have.property('host', 'veronica.dev.local')
-    expect(Cypress.env()).to.have.property('api_server', 'http://localhost:8888/v2/')
-  })
-})
-
-context('Cypress.log', () => {
-  beforeEach(() => {
-    cy.visit('http://localhost:8080/cypress-api')
-  })
-
-  it('Control what is printed to the Command Log', () => {
+    it('Control what is printed to the Command Log', () => {
     // https://on.cypress.io/cypress-log
-  })
-})
-
-context('Cypress.platform', () => {
-  beforeEach(() => {
-    cy.visit('http://localhost:8080/cypress-api')
+    })
   })
 
-  it('Get underlying OS name', () => {
+  context('Cypress.platform', () => {
+    beforeEach(() => {
+      cy.visit('http://localhost:8080/cypress-api')
+    })
+
+    it('Get underlying OS name', () => {
     // https://on.cypress.io/platform
-    expect(Cypress.platform).to.be.exist
-  })
-})
-
-context('Cypress.version', () => {
-  beforeEach(() => {
-    cy.visit('http://localhost:8080/cypress-api')
+      expect(Cypress.platform).to.be.exist
+    })
   })
 
-  it('Get current version of Cypress being run', () => {
+  context('Cypress.version', () => {
+    beforeEach(() => {
+      cy.visit('http://localhost:8080/cypress-api')
+    })
+
+    it('Get current version of Cypress being run', () => {
     // https://on.cypress.io/version
-    expect(Cypress.version).to.be.exist
-  })
-})
-
-context('Cypress.spec', () => {
-  beforeEach(() => {
-    cy.visit('http://localhost:8080/cypress-api')
+      expect(Cypress.version).to.be.exist
+    })
   })
 
-  it('Get current spec information', () => {
+  context('Cypress.spec', () => {
+    beforeEach(() => {
+      cy.visit('http://localhost:8080/cypress-api')
+    })
+
+    it('Get current spec information', () => {
     // https://on.cypress.io/spec
     // wrap the object so we can inspect it easily by clicking in the command log
-    cy.wrap(Cypress.spec).should('include.keys', ['name', 'relative', 'absolute'])
+      cy.wrap(Cypress.spec).should('include.keys', ['name', 'relative', 'absolute'])
+    })
   })
 })

--- a/cypress/e2e/2-advanced-examples/files.cy.js
+++ b/cypress/e2e/2-advanced-examples/files.cy.js
@@ -7,9 +7,7 @@ const requiredExample = require('../../fixtures/example')
 context('Files', () => {
   beforeEach(() => {
     cy.visit('http://localhost:8080/commands/files')
-  })
 
-  beforeEach(() => {
     // load example.json fixture file and store
     // in the test context object
     cy.fixture('example.json').as('example')

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "eslint": "7.0.0",
         "eslint-plugin-cypress": "2.8.1",
         "eslint-plugin-json-format": "2.0.1",
-        "eslint-plugin-mocha": "5.3.0",
+        "eslint-plugin-mocha": "10.1.0",
         "execa": "2.0.5",
         "globby": "11.1.0",
         "husky": "8.0.3",
@@ -3158,18 +3158,46 @@
       }
     },
     "node_modules/eslint-plugin-mocha": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-5.3.0.tgz",
-      "integrity": "sha512-3uwlJVLijjEmBeNyH60nzqgA1gacUWLUmcKV8PIGNvj1kwP/CTgAWQHn2ayyJVwziX+KETkr9opNwT1qD/RZ5A==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.1.0.tgz",
+      "integrity": "sha512-xLqqWUF17llsogVOC+8C6/jvQ+4IoOREbN7ZCHuOHuD6cT5cDD4h7f2LgsZuzMAiwswWE21tO7ExaknHVDrSkw==",
       "dev": true,
       "dependencies": {
-        "ramda": "^0.26.1"
+        "eslint-utils": "^3.0.0",
+        "rambda": "^7.1.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "eslint": ">= 4.0.0"
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-mocha/node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-plugin-mocha/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-scope": {
@@ -9849,10 +9877,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/ramda": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+    "node_modules/rambda": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.5.0.tgz",
+      "integrity": "sha512-y/M9weqWAH4iopRd7EHDEQQvpFPHj1AA3oHozE9tfITHUtTR7Z9PSlIRRG2l1GuW7sefC1cXFfIcF+cgnShdBA==",
       "dev": true
     },
     "node_modules/range-parser": {
@@ -14859,12 +14887,30 @@
       }
     },
     "eslint-plugin-mocha": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-5.3.0.tgz",
-      "integrity": "sha512-3uwlJVLijjEmBeNyH60nzqgA1gacUWLUmcKV8PIGNvj1kwP/CTgAWQHn2ayyJVwziX+KETkr9opNwT1qD/RZ5A==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.1.0.tgz",
+      "integrity": "sha512-xLqqWUF17llsogVOC+8C6/jvQ+4IoOREbN7ZCHuOHuD6cT5cDD4h7f2LgsZuzMAiwswWE21tO7ExaknHVDrSkw==",
       "dev": true,
       "requires": {
-        "ramda": "^0.26.1"
+        "eslint-utils": "^3.0.0",
+        "rambda": "^7.1.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
       }
     },
     "eslint-scope": {
@@ -19720,10 +19766,10 @@
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
     },
-    "ramda": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+    "rambda": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.5.0.tgz",
+      "integrity": "sha512-y/M9weqWAH4iopRd7EHDEQQvpFPHj1AA3oHozE9tfITHUtTR7Z9PSlIRRG2l1GuW7sefC1cXFfIcF+cgnShdBA==",
       "dev": true
     },
     "range-parser": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint": "7.0.0",
     "eslint-plugin-cypress": "2.8.1",
     "eslint-plugin-json-format": "2.0.1",
-    "eslint-plugin-mocha": "5.3.0",
+    "eslint-plugin-mocha": "10.1.0",
     "execa": "2.0.5",
     "globby": "11.1.0",
     "husky": "8.0.3",


### PR DESCRIPTION
This PR resolves https://github.com/cypress-io/cypress-example-kitchensink/issues/629 "mocha lint errors on example tests with eslint-plugin-mocha 10.1.0".

## eslint-plugin-mocha

[eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha) is updated to latest ([10.1.0](https://github.com/lo1tuma/eslint-plugin-mocha/releases/tag/10.1.0))

## Changes to linting

- Ignore use of arrow function syntax `() =>` using `"mocha/no-mocha-arrows": "off"` rule in `.eslintrc` configuration.

## Changes to examples

- In [cypress/e2e/2-advanced-examples/files.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/2-advanced-examples/files.cy.js) two instances of `beforeEach` are merged into one instance to fix `mocha/no-sibling-hooks`.
- In [cypress/e2e/2-advanced-examples/cypress_api.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/2-advanced-examples/cypress_api.cy.js) a new top-level `context('Cypress APIs', function() {})` is introduced which moves all existing top-level `context` instances down one level in the hierarchy.

## Verification

```bash
npm ci
npx eslint cypress
```

Ensure no errors are reported.