### PR TITLE
chore(deps): install Cypress 12.10.0 exact version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@bahmutov/print-env": "1.3.0",
         "colon-names": "1.0.0",
-        "cypress": "^12.1.0",
+        "cypress": "12.10.0",
         "eslint": "7.0.0",
         "eslint-plugin-cypress": "2.8.1",
         "eslint-plugin-json-format": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@bahmutov/print-env": "1.3.0",
     "colon-names": "1.0.0",
-    "cypress": "^12.1.0",
+    "cypress": "12.10.0",
     "eslint": "7.0.0",
     "eslint-plugin-cypress": "2.8.1",
     "eslint-plugin-json-format": "2.0.1",


### PR DESCRIPTION
This PR installs Cypress as an exact version `12.10.0`, replacing the current semantic version selection `^12.1.0`

```bash
npm install cypress@latest -D -E
```

was used.

- It works around the issue https://github.com/cypress-io/cypress-example-kitchensink/issues/645
- It prepares Cypress better for automatic updates by `renovate` 
- It has the advantage that manually viewing [package.json](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/package.json) shows the exact version in use