### PR TITLE
fix: hash workflow cache on package-lock

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -48,9 +48,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package.json') }}
+          key: cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package.json') }}
+            cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
 
       # Cache local node_modules to pass to testing jobs
       - name: Cache local node_modules
@@ -93,9 +93,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package.json') }}
+          key: cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package.json') }}
+            cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Cache local node_modules
         uses: actions/cache@v3
@@ -157,7 +157,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package.json') }}
+          key: cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             cypress-${{ runner.os }}-cypress-${{ github.ref }}-
 

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/Cypress
-        key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}
+        key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package-lock.json') }}
 
     - name: install dependencies and verify Cypress
       env:


### PR DESCRIPTION
- This PR resolves https://github.com/cypress-io/cypress-example-kitchensink/issues/645.

- It keys the Cypress [Linux binary cache](https://docs.cypress.io/guides/references/advanced-installation#Binary-cache) located at `~/.cache/Cypress` on `package-lock.json` instead of `package.json`.

- Since it is possible to update the installed Cypress version by changing only `package-lock.json`, as in renovate's PR https://github.com/cypress-io/cypress-example-kitchensink/pull/640, the workflows listed below need to start a new cache in this case.

It modifies the following two GitHub action workflows:

- [.github/workflows/parallel.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/parallel.yml) and
- [.github/workflows/single.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/parallel.yml)

