### PR TITLE
chore(deps): update eslint-plugin-cypress to 2.13.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "colon-names": "1.0.0",
         "cypress": "12.10.0",
         "eslint": "8.38.0",
-        "eslint-plugin-cypress": "2.8.1",
+        "eslint-plugin-cypress": "2.13.2",
         "eslint-plugin-json-format": "2.0.1",
         "eslint-plugin-mocha": "10.1.0",
         "execa": "2.0.5",
@@ -3175,9 +3175,9 @@
       }
     },
     "node_modules/eslint-plugin-cypress": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.8.1.tgz",
-      "integrity": "sha512-jDpcP+MmjmqQO/x3bwIXgp4cl7Q66RYS5/IsuOQP4Qo2sEqE3DI8tTxBQ1EhnV5qEDd2Z2TYHR+5vYI6oCN4uw==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.13.2.tgz",
+      "integrity": "sha512-LlwjnBTzuKuC0A4H0RxVjs0YeAWK+CD1iM9Dp8un3lzT713ePQxfpPstCD+9HSAss8emuE3b2hCNUST+NrUwKw==",
       "dev": true,
       "dependencies": {
         "globals": "^11.12.0"
@@ -14788,9 +14788,9 @@
       }
     },
     "eslint-plugin-cypress": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.8.1.tgz",
-      "integrity": "sha512-jDpcP+MmjmqQO/x3bwIXgp4cl7Q66RYS5/IsuOQP4Qo2sEqE3DI8tTxBQ1EhnV5qEDd2Z2TYHR+5vYI6oCN4uw==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.13.2.tgz",
+      "integrity": "sha512-LlwjnBTzuKuC0A4H0RxVjs0YeAWK+CD1iM9Dp8un3lzT713ePQxfpPstCD+9HSAss8emuE3b2hCNUST+NrUwKw==",
       "dev": true,
       "requires": {
         "globals": "^11.12.0"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "colon-names": "1.0.0",
     "cypress": "12.10.0",
     "eslint": "8.38.0",
-    "eslint-plugin-cypress": "2.8.1",
+    "eslint-plugin-cypress": "2.13.2",
     "eslint-plugin-json-format": "2.0.1",
     "eslint-plugin-mocha": "10.1.0",
     "execa": "2.0.5",


### PR DESCRIPTION
This PR updates [eslint-plugin-cypress](https://www.npmjs.com/package/eslint-plugin-cypress) from `2.8.1` to [v2.13.2](https://github.com/cypress-io/eslint-plugin-cypress/releases/tag/v2.13.2)

## Benefit

Using the most up-to-date version of [eslint-plugin-cypress](https://www.npmjs.com/package/eslint-plugin-cypress) helps ensure quality examples to be integrated into the Cypress product.

## Verification

```bash
npm ci
npm run lint
```
