### PR TITLE
docs: remove outdated intro animated gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Kitchen Sink [![renovate-app badge][renovate-badge]][renovate-app] [![semantic-release][semantic-image] ][semantic-url]
 
-![kitchensink](https://cloud.githubusercontent.com/assets/1268976/14084252/e309e370-f4e7-11e5-9562-24f516563ac9.gif)
-
 This is an example app used to showcase [Cypress.io](https://www.cypress.io/) testing. The application uses every API command in Cypress for demonstration purposes. Additionally this example app is configured to run tests in various CI platforms. The [tests](https://github.com/cypress-io/cypress-example-kitchensink/tree/master/cypress/e2e) are also heavily commented. For a full reference of our documentation, go to [docs.cypress.io](https://docs.cypress.io/).
 
 To see the kitchen sink application, visit [example.cypress.io](https://example.cypress.io/).


### PR DESCRIPTION

This PR removes the non-working link to https://cloud.githubusercontent.com/assets/1268976/14084252/e309e370-f4e7-11e5-9562-24f516563ac9.gif which is an  outdated animated gif graphic at the top of the [README](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/README.md) file.

## Background

The link https://cloud.githubusercontent.com/assets/1268976/14084252/e309e370-f4e7-11e5-9562-24f516563ac9.gif currently does not work. Attempting to view it, results in the message "Error 503 Backend is unhealthy". I reported this into https://github.com/orgs/community/discussions/53428, however there has been no response from GitHub so far.

![image](https://user-images.githubusercontent.com/66998419/233686049-0724c050-507f-4dd4-be6e-6b26a65c54bf.png)

Internet history shows that it was working on December 21, 2022:

https://web.archive.org/web/20221221212458/https://cloud.githubusercontent.com/assets/1268976/14084252/e309e370-f4e7-11e5-9562-24f516563ac9.gif

## Reason for removal

The animated graphic displays what happens when calling the Cypress tests using a very old version of Cypress. This is not representative of using the tests under current 12.x versions of Cypress. It would be possible to retrieve it from Internet history and display it using other means, however since its contents are so out of date, displaying it is more likely to cause confusion than anything else. I suggest that removing it is the best option.
