### PR TITLE
docs: add link to Cypress CI documentation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ You can find all CI results recorded on the [![Cypress Dashboard](https://img.sh
 
 If you are looking for BitBucket Pipelines example, check out [bitbucket.org/cypress-io/cypress-example-kitchensink](https://bitbucket.org/cypress-io/cypress-example-kitchensink).
 
+The Cypress documentation page [CI Provider Examples](https://docs.cypress.io/guides/continuous-integration/ci-provider-examples) provides additional examples with extensive guides for using Cypress with some of the most popular CI providers.
+
 ## Cypress on CI Workshop
 
 Cypress team has created a full workshop showing how to run Cypress on popular CI providers. Find the workshop at [github.com/cypress-io/cypress-workshop-ci](https://github.com/cypress-io/cypress-workshop-ci).


### PR DESCRIPTION
This PR adds a link to the Cypress documentation page

[CI Provider Examples](https://docs.cypress.io/guides/continuous-integration/ci-provider-examples)

where links to live CI examples from the [Real World App (RWA)](https://github.com/cypress-io/cypress-realworld-app) are listed. This expands on the examples listed in this ([cypress-example-kitchensink](https://github.com/cypress-io/cypress-example-kitchensink)) repository.

## Real World Example - Live CI workflows

- [CircleCI](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.circleci/config.yml)
- [GitHub-Action](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.github/workflows/main.yml)
- [Bitbucket](https://github.com/cypress-io/cypress-realworld-app/blob/develop/bitbucket-pipelines.yml)
- [GitLab](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.gitlab-ci.yml)
- [AWS CodeBuild](https://github.com/cypress-io/cypress-realworld-app/blob/develop/buildspec.yml)

