### PR TITLE
docs: add legacy to community examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ Cypress team has created a full workshop showing how to run Cypress on popular C
 
 ## CI Community Examples
 
-CI | Url
+CI | Link
 :--- | :--- |
-IBM Cloud CI | [Cloud Foundry](https://github.com/iamgollum/cypress-example-kitchensink/tree/281-ibm-cloud-pipeline)
-GitLab CI | [Example caching when installing using Yarn](https://gitlab.com/bahmutov/cypress-yarn-gitlab-ci-example)
-CodeFresh | [bahmutov/cypress-codefresh-example](https://github.com/bahmutov/cypress-codefresh-example)
+IBM Cloud CI (legacy) | [Cloud Foundry](https://github.com/iamgollum/cypress-example-kitchensink/tree/281-ibm-cloud-pipeline)
+GitLab CI (legacy) | [Example caching when installing using Yarn](https://gitlab.com/bahmutov/cypress-yarn-gitlab-ci-example)
+CodeFresh (legacy) | [bahmutov/cypress-codefresh-example](https://github.com/bahmutov/cypress-codefresh-example)
 
 ## Help + Testing
 


### PR DESCRIPTION
This PR adds a `legacy` notation to each of the [README > CI Community Examples](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/README.md#ci-community-examples) since each of these examples is outdated. They are currently displayed as:

---

## CI Community Examples

CI | Url
:--- | :--- |
IBM Cloud CI | [Cloud Foundry](https://github.com/iamgollum/cypress-example-kitchensink/tree/281-ibm-cloud-pipeline)
GitLab CI | [Example caching when installing using Yarn](https://gitlab.com/bahmutov/cypress-yarn-gitlab-ci-example)
CodeFresh | [bahmutov/cypress-codefresh-example](https://github.com/bahmutov/cypress-codefresh-example)

---

## Comments

### IBM Cloud CI

[Cloud Foundry](https://github.com/iamgollum/cypress-example-kitchensink/tree/281-ibm-cloud-pipeline)

is a link to https://github.com/iamgollum/cypress-example-kitchensink/tree/281-ibm-cloud-pipeline and this contains an unmaintained fork of this repository based on Cypress `3.4.1`. It was last updated on Aug 8, 2019.

There is no specific documentation about how to use it, what it achieves, or where to find the results of running it. The core of the pipeline seems to be in [.bluemix/pipeline.yml](https://github.com/iamgollum/cypress-example-kitchensink/blob/281-ibm-cloud-pipeline/.bluemix/pipeline.yml)

- It was added through https://github.com/cypress-io/cypress-example-kitchensink/pull/302.

- https://github.com/iamgollum/cypress-example-kitchensink/issues/1 requests the owner if they have any plans to update it.

### GitLab CI

[Example caching when installing using Yarn](https://gitlab.com/bahmutov/cypress-yarn-gitlab-ci-example)

is a link to https://gitlab.com/bahmutov/cypress-yarn-gitlab-ci-example.

This is a legacy example, last updated Nov 15, 2019. It is based on Cypress `3.6.1`, Node.js `12` and Yarn Classic (version 1).

### CodeFresh

[bahmutov/cypress-codefresh-example](https://github.com/bahmutov/cypress-codefresh-example)

is a link to https://github.com/bahmutov/cypress-codefresh-example

This is a legacy example, last updated Feb 17, 2021. It is based on Cypress `6.5.0` and Node.js `12`.
