### PR TITLE
chore: disable eslint cypress/no-unnecessary-waiting rule checking in examples

### DIFF
--- a/cypress/e2e/2-advanced-examples/viewport.cy.js
+++ b/cypress/e2e/2-advanced-examples/viewport.cy.js
@@ -1,4 +1,5 @@
 /// <reference types="cypress" />
+/* eslint-disable cypress/no-unnecessary-waiting */
 
 context('Viewport', () => {
   beforeEach(() => {

--- a/cypress/e2e/2-advanced-examples/waiting.cy.js
+++ b/cypress/e2e/2-advanced-examples/waiting.cy.js
@@ -1,4 +1,5 @@
 /// <reference types="cypress" />
+/* eslint-disable cypress/no-unnecessary-waiting */
 
 context('Waiting', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Issue

If the eslint rule `cypress/no-unnecessary-waiting` from [eslint-plugin-cypress: Rules](https://github.com/cypress-io/eslint-plugin-cypress#rules) is enabled, then some examples from [cypress/e2e/2-advanced-examples](https://github.com/cypress-io/cypress-example-kitchensink/tree/master/cypress/e2e/2-advanced-examples) fail linting with the message:

"error  Do not wait for arbitrary time periods  cypress/no-unnecessary-waiting"

## Background

`cypress/no-unnecessary-waiting` belongs to the set of `plugin:cypress/recommended` rules as defined in [eslint-plugin-cypress: Rules](https://github.com/cypress-io/eslint-plugin-cypress#rules), so it can be expected that this set of rules is commonly applied by default.

The examples which fail this rule contains legitimate and responsible demonstrations of `cy.wait()`:

- [viewport.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/2-advanced-examples/viewport.cy.js) example is commented with:

https://github.com/cypress-io/cypress-example-kitchensink/blob/e67e0ad435e0e9c31525767cc2ec23e8f48193d5/cypress/e2e/2-advanced-examples/viewport.cy.js#L25-L26

- [waiting.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/2-advanced-examples/waiting.cy.js) example warns about the use of `cy.wait()`

https://github.com/cypress-io/cypress-example-kitchensink/blob/e67e0ad435e0e9c31525767cc2ec23e8f48193d5/cypress/e2e/2-advanced-examples/waiting.cy.js#L7-L8

## Change

This PR disables eslint checking against the rule `cypress/no-unnecessary-waiting` according to [Disable rules](https://github.com/cypress-io/eslint-plugin-cypress#disable-rules)

```js
/* eslint-disable cypress/no-unnecessary-waiting */
```

for the whole of both of the following example files:

- [cypress/e2e/2-advanced-examples/viewport.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/2-advanced-examples/viewport.cy.js)
- [cypress/e2e/2-advanced-examples/waiting.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/2-advanced-examples/waiting.cy.js)

`cy.wait()` is used in these examples in a controlled and necessary way, and so the use should not be flagged as an error.

## Verification

Add `"cypress/no-unnecessary-waiting": "error"` to `rules` of [.eslintrc](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.eslintrc), similar to the following

```json
  "rules": {
    "cypress/no-unnecessary-waiting": "error"
  }
```

Execute:

```bash
npm run lint
```
