### PR TITLE
ci: add eslint cypress/recommended

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": [
     "eslint:recommended",
+    "plugin:cypress/recommended",
     "plugin:mocha/recommended"
   ],
   "plugins": [
@@ -13,6 +14,7 @@
   },
   "rules": {
     "indent": ["error", 2, { "SwitchCase": 1, "MemberExpression": "off" }],
+    "cypress/unsafe-to-chain-command": "off",
     "mocha/no-exclusive-tests": "error",
     "mocha/no-mocha-arrows": "off"
   }

--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
   },
   "rules": {
     "indent": ["error", 2, { "SwitchCase": 1, "MemberExpression": "off" }],
+    // TODO: remove after https://github.com/cypress-io/cypress-example-kitchensink/issues/661 has been resolved
     "cypress/unsafe-to-chain-command": "off",
     "mocha/no-exclusive-tests": "error",
     "mocha/no-mocha-arrows": "off"


### PR DESCRIPTION
This PR is an enhancement to the CI process of the repository. It adds the [eslint-plugin-cypress > Recommended configuration](https://github.com/cypress-io/eslint-plugin-cypress#recommended-configuration) to the set of rules which are checked.

## Change

The [.eslintrc](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.eslintrc) ESLint configuration file has the following configuration option added:

```json
  "extends": [
    "plugin:cypress/recommended"
  ],
```

Additionally, and pending resolution of issue https://github.com/cypress-io/cypress-example-kitchensink/issues/661, the eslint rule `cypress/unsafe-to-chain-command` from [eslint-plugin-cypress: Rules](https://github.com/cypress-io/eslint-plugin-cypress#rules) is disabled:

```json
  "rules": {
    "cypress/unsafe-to-chain-command": "off"
  }
```

PR https://github.com/cypress-io/cypress-example-kitchensink/pull/662 already disabled the eslint rule `cypress/no-unnecessary-waiting` from [eslint-plugin-cypress: Rules](https://github.com/cypress-io/eslint-plugin-cypress#rules) in the following tests to prevent the rule being applied where it did not fit:

- [cypress/e2e/2-advanced-examples/viewport.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/2-advanced-examples/viewport.cy.js)
- [cypress/e2e/2-advanced-examples/waiting.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/2-advanced-examples/waiting.cy.js)

## Benefit

Linting against the set of rules defined by [eslint-plugin-cypress > Recommended configuration](https://github.com/cypress-io/eslint-plugin-cypress#recommended-configuration) ensures that the Cypress examples adhere to a documented set of Cypress standard rules. This retains the on-going quality of the examples provided and their ease-of-use.

## Verification

Execute:

```bash
npm ci
npm run lint
```

and confirm that no errors are reported.

## References

- [ESLint Documentation](https://eslint.org/docs/latest/)
