### PR TITLE
chore: Add note to Azure example

### DIFF
--- a/azure-ci.yml
+++ b/azure-ci.yml
@@ -53,8 +53,8 @@ jobs:
       # To record on Cypress dashboard we need to set CYPRESS_RECORD_KEY environment variable.
       # For setting ci-build-id, BUILD_BUILDNUMBER is a good candidate
 
-      # Note that `npm run start & npx cypress run` is included below for brevity only,
-      # it is not ideal because you may need to wait longer for the server to be ready.
+      # Note that `npm run start & npx cypress run` is included below for brevity only.
+      # This pattern is not ideal because Cypress may run before the server reaches a true ready state.
       # For better solutions see https://on.cypress.io/guides/continuous-integration.
       - script: |
           npx print-env AGENT

--- a/azure-ci.yml
+++ b/azure-ci.yml
@@ -52,6 +52,10 @@ jobs:
       # The test artifacts (video, screenshots, test output) will be uploaded to Cypress dashboard.
       # To record on Cypress dashboard we need to set CYPRESS_RECORD_KEY environment variable.
       # For setting ci-build-id, BUILD_BUILDNUMBER is a good candidate
+
+      # Note that `npm run start & npx cypress run` is included below for brevity only,
+      # it is not ideal because you may need to wait longer for the server to be ready.
+      # For better solutions see https://on.cypress.io/guides/continuous-integration.
       - script: |
           npx print-env AGENT
           npx print-env BUILD


### PR DESCRIPTION
Closes https://github.com/cypress-io/cypress-example-kitchensink/issues/664.

Since we do not recommend the pattern we use in the example, we should help folks find the patterns we do recommend.

I can see that the example itself makes some sense as it is, since it avoids external dependencies, so I think the example itself is OK.

