### PR TITLE
chore: rename cypress dashboard to cypress cloud

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ workflows:
     jobs:
       # checks out code and installs dependencies once
       # runs on 3 machines, load balances tests
-      # and records on Cypress Dashboard
+      # and records on Cypress Cloud
       - cypress/run:
           name: '3 machines'
           post-install: 'npm run build'

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       # when one test fails, DO NOT cancel the other
       # containers, because this will kill Cypress processes
-      # leaving the Dashboard hanging ...
+      # leaving the Cypress Cloud dashboard hanging ...
       # https://github.com/cypress-io/github-action/issues/48
       fail-fast: false
       matrix:
@@ -54,7 +54,7 @@ jobs:
     strategy:
       # when one test fails, DO NOT cancel the other
       # containers, because this will kill Cypress processes
-      # leaving the Dashboard hanging ...
+      # leaving the Cypress Cloud dashboard hanging ...
       # https://github.com/cypress-io/github-action/issues/48
       fail-fast: false
       matrix:
@@ -81,5 +81,5 @@ jobs:
           # but for this particular project on Windows we need a different start command
           start-windows: npm run start
         env:
-          # pass the Dashboard record key as an environment variable
+          # pass the Cypress Cloud (dashboard) record key as an environment variable
           CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
     // from the previous stage
     stage('cypress parallel tests') {
       environment {
-        // we will be recording test results and video on Cypress dashboard
+        // we will be recording test results and video on Cypress Cloud
         // to record we need to set an environment variable
         // we can load the record key variable from credentials store
         // see https://jenkins.io/doc/book/using/using-credentials/
@@ -79,7 +79,7 @@ pipeline {
       // https://jenkins.io/doc/book/pipeline/syntax/#parallel
       parallel {
         // start several test jobs in parallel, and they all
-        // will use Cypress Dashboard to load balance any found spec files
+        // will use Cypress Cloud to load balance any found spec files
         stage('tester A') {
           steps {
             echo "Running build ${env.BUILD_ID}"

--- a/azure-ci.yml
+++ b/azure-ci.yml
@@ -49,8 +49,8 @@ jobs:
         displayName: 'Cypress info'
 
       # The next command starts the server and runs Cypress end-to-end tests against it.
-      # The test artifacts (video, screenshots, test output) will be uploaded to Cypress dashboard.
-      # To record on Cypress dashboard we need to set CYPRESS_RECORD_KEY environment variable.
+      # The test artifacts (video, screenshots, test output) will be uploaded to Cypress Cloud.
+      # To record on Cypress Cloud we need to set CYPRESS_RECORD_KEY environment variable.
       # For setting ci-build-id, BUILD_BUILDNUMBER is a good candidate
       - script: |
           npx print-env AGENT

--- a/basic/.travis.yml
+++ b/basic/.travis.yml
@@ -23,7 +23,7 @@ cache:
 script:
   # start server in the background
   - npm run start &
-  # run all Cypress tests and record on the dashboard
+  # run all Cypress tests and record on Cypress Cloud
   - npm run cy:run -- --record
   # after all tests finish running we need
   # to kill all background jobs (like "npm start &")

--- a/basic/Jenkinsfile
+++ b/basic/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
   stages {
     stage('build and test') {
       environment {
-        // we will be recording test results and video on Cypress dashboard
+        // we will be recording test results and video on Cypress Cloud
         // to record we need to set an environment variable
         // we can load the record key variable from credentials store
         // see https://jenkins.io/doc/book/using/using-credentials/

--- a/basic/azure-ci.yml
+++ b/basic/azure-ci.yml
@@ -39,7 +39,7 @@ jobs:
         displayName: 'Cypress verify'
 
       # The next command starts the server and runs Cypress end-to-end tests against it.
-      # The test artifacts (video, screenshots, test output) will be uploaded to Cypress dashboard
-      # To record on Cypress dashboard we need to set CYPRESS_RECORD_KEY environment variable
+      # The test artifacts (video, screenshots, test output) will be uploaded to Cypress Cloud
+      # To record on Cypress Cloud we need to set CYPRESS_RECORD_KEY environment variable
       - script: npm run test:ci:record
         displayName: 'Run Cypress tests'

--- a/basic/buildspec.yml
+++ b/basic/buildspec.yml
@@ -5,7 +5,7 @@ phases:
     runtime-versions:
       nodejs: latest
     commands:
-      # Set COMMIT_INFO variables to send Git specifics to Cypress Dashboard when recording
+      # Set COMMIT_INFO variables to send Git specifics to Cypress Cloud when recording
       # https://docs.cypress.io/guides/continuous-integration/introduction#Git-information
       - export COMMIT_INFO_BRANCH="$(git rev-parse HEAD | xargs git name-rev | cut -d' ' -f2 | sed 's/remotes\/origin\///g')"
       - export COMMIT_INFO_MESSAGE="$(git log -1 --pretty=%B)"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -26,7 +26,7 @@ phases:
     runtime-versions:
       nodejs: latest
     commands:
-      # Set COMMIT_INFO variables to send Git specifics to Cypress Dashboard when recording
+      # Set COMMIT_INFO variables to send Git specifics to Cypress Cloud when recording
       # https://docs.cypress.io/guides/continuous-integration/introduction#Git-information
       - export COMMIT_INFO_BRANCH="$(git rev-parse HEAD | xargs git name-rev | cut -d' ' -f2 | sed 's/remotes\/origin\///g')"
       - export COMMIT_INFO_MESSAGE="$(git log -1 --pretty=%B)"
@@ -42,7 +42,7 @@ phases:
   build:
     # Per https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
     # use $CODEBUILD_INITIATOR as it provides the entity that started the build
-    # which is unique and can be used as the --ci-build-id for the Cypress Dashboard
+    # which is unique and can be used as the --ci-build-id for the Cypress Cloud
     # e.g. awsCodeBuild-cypress-kitchen-sink/AWSCodeBuild-a14fc8e3-b5d6-42f9-9067-345d48a8f0fd
     commands:
         - npm run start &


### PR DESCRIPTION
This PR changes comments referring to the (Cypress) dashboard to refer instead to Cypress Cloud.
