### PR TITLE
build: add scripts to Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /home/node/app
 COPY package.json package-lock.json ./
 COPY app ./app
 COPY serve.json ./
+COPY scripts ./scripts
 # copy Cypress tests
 COPY cypress.config.js cypress ./
 COPY cypress ./cypress
@@ -21,4 +22,4 @@ ENV CI=1
 # install NPM dependencies and Cypress binary
 RUN npm ci
 # check if the binary was installed successfully
-RUN $(npm bin)/cypress verify
+RUN npx cypress verify

--- a/basic/codeship-pro/Dockerfile
+++ b/basic/codeship-pro/Dockerfile
@@ -9,6 +9,8 @@ WORKDIR /home/node/app
 # copy our test application
 COPY package.json package-lock.json ./
 COPY app ./app
+COPY serve.json ./
+COPY scripts ./scripts
 # copy Cypress tests
 COPY cypress.config.js cypress ./
 COPY cypress ./cypress
@@ -20,4 +22,4 @@ ENV CI=1
 # install NPM dependencies and Cypress binary
 RUN npm ci
 # check if the binary was installed successfully
-RUN $(npm bin)/cypress verify
+RUN npx cypress verify


### PR DESCRIPTION
Scripts folder needed when creating a docker image with "docker build". If the folder is not copied, then "RUN npm ci" will throw the following error: 
"Error: Cannot find module '/home/node/app/scripts/prepare.js'"