### PR TITLE
chore: update to use latest cypress-io/circleci-orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@
 version: 2.1
 orbs:
   # use Cypress orb from CircleCI registry
-  cypress: cypress-io/cypress@3.1.2
+  cypress: cypress-io/cypress@3.1.3
 
 executors:
   mac:


### PR DESCRIPTION
chore: update to use latest cypress-io/circleci-orb