### PR TITLE
docs: convert `$(npm bin)` in examples to `npx`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,13 +15,13 @@ steps:
 
       # if necessary, reinstall "correct" version of Cypress
       # a common situation if testing preview binary build
-      # "$(npm bin)/cypress" install --force
+      # npx cypress install --force
       #
       echo "--- Install custom Cypress version"
       npm install "$CYPRESS_NPM_PACKAGE_NAME"
 
       echo "--- Cypress version"
-      "$(npm bin)/cypress" version
+      npx cypress version
 
       echo "+++ Run Cypress tests"
       npm run test:ci:record

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ install:
     # useful to make sure we are not carrying around old versions
     - npx cypress cache path
     - npx cypress cache list
-    - $(npm bin)/print-env CI
+    - npx print-env CI
     - npm run cy:verify
     - npm run cy:info
 
@@ -39,7 +39,7 @@ install:
   stage: test
   script:
     # print CI environment variables for reference
-    - $(npm bin)/print-env CI
+    - npx print-env CI
     # start the server in the background
     - npm run start &
     # run Cypress test in load balancing mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ cache:
 defaults: &defaults
   script:
     #   ## print all Travis environment variables for debugging
-    - $(npm bin)/print-env TRAVIS
+    - npx print-env TRAVIS
     - npm run start &
     - npm run cy:run -- --record --parallel --group $STAGE_NAME
     # after all tests finish running we need

--- a/basic/.gitlab-ci.yml
+++ b/basic/.gitlab-ci.yml
@@ -18,7 +18,7 @@ test:
   script:
     - npm ci
     # print CI environment variables for reference
-    - $(npm bin)/print-env CI
+    - npx print-env CI
     # make sure Cypress can run
     - npm run cy:verify
     # start the server in the background


### PR DESCRIPTION
This PR converts several documentation-only CI example instances which were using `$(npm bin)` to use instead `npx`. The `$(npm bin)` method is no longer available in Node.js `18` used by this repo. The equivalent is `npx` and `npm exec`.

`$(npm bin)` was being used to execute `cypress` and `print-env`.

There is no environment set up to test the changed CI examples. The changes are "best effort" to improve the chance that the examples would work if used.

## Background

- This repo is based on using Node.js `18` as defined in [.node-version](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.node-version)
- Node.js `18` includes `npm` version `9`.
- For `npm` version 9.x or higher, the command `npm bin` has been removed. The replacement for `npm bin` is `npx` and `npm exec` to execute binaries. (See [npm v9.0.0 released](https://github.blog/changelog/2022-10-24-npm-v9-0-0-released/) Oct 24, 2022).
- Thus `npm bin` is not available in connection with this repo and should be replaced.