### PR TITLE
chore(deps): update to cypress-io/github-action@v6

### DIFF
--- a/.github/workflows/chrome-docker.yml
+++ b/.github/workflows/chrome-docker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Chrome
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         timeout-minutes: 10
         with:
           build: npm run build

--- a/.github/workflows/chrome.yml
+++ b/.github/workflows/chrome.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Chrome
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         timeout-minutes: 10
         with:
           build: npm run build

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Cypress run
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         timeout-minutes: 10
         with:
           build: npm run build
@@ -38,7 +38,7 @@ jobs:
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         timeout-minutes: 5
         with:
           record: true
@@ -70,7 +70,7 @@ jobs:
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         timeout-minutes: 10
         with:
           record: true


### PR DESCRIPTION
This PR migrates workflows in [.github/workflows](https://github.com/cypress-io/cypress-example-kitchensink/tree/master/.github/workflows)

- from `cypress-io/github-action@v5` running under `node16`
- to `cypress-io/github-action@v6` running under `node20`

Node.js `16` enters [end-of-life](https://github.com/nodejs/release#release-schedule) on Sep 11, 2023.