### PR TITLE
ci: remove failing video upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,8 +58,6 @@ jobs:
           no_output_timeout: '1m'
       - store_artifacts:
           path: cypress\screenshots
-      - store_artifacts:
-          path: cypress\videos
 
   win-test-chrome:
     working_directory: ~/app
@@ -101,8 +99,6 @@ jobs:
           no_output_timeout: '1m'
       - store_artifacts:
           path: cypress\screenshots
-      - store_artifacts:
-          path: cypress\videos
 
   win-test-firefox:
     working_directory: ~/app
@@ -144,8 +140,6 @@ jobs:
           no_output_timeout: '1m'
       - store_artifacts:
           path: cypress\screenshots
-      - store_artifacts:
-          path: cypress\videos
 
   mac-test:
     executor: mac

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -122,7 +122,7 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}
           TERM: xterm
 
-      # Save videos and screenshots as test artifacts
+      # Save screenshots as test artifacts
       # https://github.com/actions/upload-artifact
       - uses: actions/upload-artifact@v3
         # there might be no screenshots created when:
@@ -132,11 +132,6 @@ jobs:
         with:
           name: screenshots
           path: cypress/screenshots
-      # video should always be generated
-      - uses: actions/upload-artifact@v3
-        with:
-          name: videos
-          path: cypress/videos
 
   test2:
     name: Cypress test 2
@@ -186,7 +181,7 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}
           TERM: xterm
 
-      # Save videos and screenshots as test artifacts
+      # Save screenshots as test artifacts
       # https://github.com/actions/upload-artifact
       - uses: actions/upload-artifact@v3
         # there might be no screenshots created when:
@@ -196,8 +191,3 @@ jobs:
         with:
           name: screenshots
           path: cypress/screenshots
-      # video should always be generated
-      - uses: actions/upload-artifact@v3
-        with:
-          name: videos
-          path: cypress/videos

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -64,7 +64,7 @@ jobs:
         CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}
         TERM: xterm
 
-    # Save videos and screenshots as test artifacts
+    # Save screenshots as test artifacts
     # https://github.com/actions/upload-artifact
     - uses: actions/upload-artifact@v3
         # there might be no screenshots created when:
@@ -74,8 +74,3 @@ jobs:
       with:
         name: screenshots
         path: cypress/screenshots
-    # video should always be generated
-    - uses: actions/upload-artifact@v3
-      with:
-        name: videos
-        path: cypress/videos

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,6 @@ install:
   artifacts:
     when: always
     paths:
-      - cypress/videos/**/*.mp4
       - cypress/screenshots/**/*.png
     expire_in: 1 day
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,13 +66,13 @@ pipeline {
     // from the previous stage
     stage('cypress parallel tests') {
       environment {
-        // we will be recording test results and video on Cypress Cloud
+        // we will be recording test results on Cypress Cloud
         // to record we need to set an environment variable
         // we can load the record key variable from credentials store
         // see https://jenkins.io/doc/book/using/using-credentials/
         CYPRESS_RECORD_KEY = credentials('cypress-example-kitchensink-record-key')
         // because parallel steps share the workspace they might race to delete
-        // screenshots and videos folders. Tell Cypress not to delete these folders
+        // screenshots folders. Tell Cypress not to delete these folders
         CYPRESS_trashAssetsBeforeRuns = 'false'
       }
 

--- a/azure-ci.yml
+++ b/azure-ci.yml
@@ -49,7 +49,7 @@ jobs:
         displayName: 'Cypress info'
 
       # The next command starts the server and runs Cypress end-to-end tests against it.
-      # The test artifacts (video, screenshots, test output) will be uploaded to Cypress Cloud.
+      # The test artifacts (screenshots, test output) will be uploaded to Cypress Cloud.
       # To record on Cypress Cloud we need to set CYPRESS_RECORD_KEY environment variable.
       # For setting ci-build-id, BUILD_BUILDNUMBER is a good candidate
 

--- a/basic/.gitlab-ci.yml
+++ b/basic/.gitlab-ci.yml
@@ -27,6 +27,5 @@ test:
     - npm run e2e:record
   artifacts:
     paths:
-      - cypress/videos
       - cypress/screenshots
     expire_in: 1 day

--- a/basic/Jenkinsfile
+++ b/basic/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
   stages {
     stage('build and test') {
       environment {
-        // we will be recording test results and video on Cypress Cloud
+        // we will be recording test results on Cypress Cloud
         // to record we need to set an environment variable
         // we can load the record key variable from credentials store
         // see https://jenkins.io/doc/book/using/using-credentials/

--- a/basic/azure-ci.yml
+++ b/basic/azure-ci.yml
@@ -39,7 +39,7 @@ jobs:
         displayName: 'Cypress verify'
 
       # The next command starts the server and runs Cypress end-to-end tests against it.
-      # The test artifacts (video, screenshots, test output) will be uploaded to Cypress Cloud
+      # The test artifacts (screenshots & test output) will be uploaded to Cypress Cloud
       # To record on Cypress Cloud we need to set CYPRESS_RECORD_KEY environment variable
       - script: npm run test:ci:record
         displayName: 'Run Cypress tests'


### PR DESCRIPTION
This PR removes failing video upload from CI workflows.

Starting with Cypress `13.0.0` videos are no longer recorded by default.

## References

- [References > Configuration > Options > Videos](https://docs.cypress.io/guides/references/configuration#Videos)
- [Migrating to Cypress 13.0 > Video updates](https://docs.cypress.io/guides/references/migration-guide#Video-updates)