### PR TITLE
docs: remove legacy community examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,6 @@ CI Provider |  Basic Config | Full Parallel Config
 
 The Cypress documentation page [CI Provider Examples](https://docs.cypress.io/guides/continuous-integration/ci-provider-examples) provides some more examples with extensive guides for using Cypress with some of the most popular CI providers.
 
-## CI Community Examples
-
-CI | Link
-:--- | :--- |
-IBM Cloud CI (legacy) | [Cloud Foundry](https://github.com/iamgollum/cypress-example-kitchensink/tree/281-ibm-cloud-pipeline)
-GitLab CI (legacy) | [Example caching when installing using Yarn](https://gitlab.com/bahmutov/cypress-yarn-gitlab-ci-example)
-CodeFresh (legacy) | [bahmutov/cypress-codefresh-example](https://github.com/bahmutov/cypress-codefresh-example)
-
 ## Help + Testing
 
 **If you get stuck, here is more help:**


### PR DESCRIPTION
This PR removes legacy [CI Community Examples](https://github.com/cypress-io/cypress-example-kitchensink#ci-community-examples) from the [README](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/README.md) file.

## CI Community Examples

| CI                    | Link                                                                                                     | Cypress<br>version | Last update  |
| :-------------------- | :------------------------------------------------------------------------------------------------------- | --------------- | ------------ |
| IBM Cloud CI (legacy) | [Cloud Foundry](https://github.com/iamgollum/cypress-example-kitchensink/tree/281-ibm-cloud-pipeline)    | `3.4.1`         | Aug 8, 2019  |
| GitLab CI (legacy)    | [Example caching when installing using Yarn](https://gitlab.com/bahmutov/cypress-yarn-gitlab-ci-example) | `3.6.1`         | Nov 15, 2019 |
| CodeFresh (legacy)    | [bahmutov/cypress-codefresh-example](https://github.com/bahmutov/cypress-codefresh-example)              | `6.5.0`         | Feb 17, 2021 |

## Reason

The examples to be removed are each between 2 and 4 years out-of-date, unmaintained and show CI usage with legacy versions of Cypress < `10.x`. They are more likely to be confusing than helpful.