### PR TITLE
ci: update appveyor to run on node.js 20

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,10 +3,13 @@ skip_commits:
   # do not run for testing new Linux builds
   message: /Testing new linux/
 
+# https://www.appveyor.com/docs/build-environment/#build-worker-images
+image: Visual Studio 2022
+
 # https://www.appveyor.com/docs/lang/nodejs-iojs/
 # Test against the latest version of this Node.js version
 environment:
-  nodejs_version: "18"
+  nodejs_version: "20"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,8 @@ test_script:
   - setx CYPRESS_defaultCommandTimeout 20000
   - run-if npm run test:ci:record:chrome
   - run-if npm run test:ci:record
-  - run-if npm run test:ci:record:firefox
+  # removed Firefox test due to flakiness in this environment
+  # - run-if npm run test:ci:record:firefox
   - run-if npm run test:ci:record:edge
 
 # Don't actually build.


### PR DESCRIPTION
## Node.js 18 to 20

This PR updates the [appveyor.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/appveyor.yml) CI workflow to run under the default Node.js `20` as specified in [.node-version](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.node-version)

https://github.com/cypress-io/cypress-example-kitchensink/blob/277e055329a3c1a07674aeaf42d882488dcdbb78/.node-version#L1

## Visual Studio 2022 image

It also explicitly specifies to use the `Visual Studio 2022` image for clarity of the example (the default would be `Visual Studio 2015`, although this can also be overridden in the UI), see [Build worker images](https://www.appveyor.com/docs/build-environment/#build-worker-images).

## Firefox removal

The Firefox test is removed from the Appveyor CI workflow, since it has proved to be flakey in the Appyeyor environment. It starts testing and then, after a random single-figure number of successfully executed tests, it fails to connect to Firefox ("Cypress failed to make a connection to the Chrome DevTools Protocol after retrying for 50 seconds.").

Firefox on Windows is already tested in the [CircleCI workflow](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.circleci/config.yml) so removing it from the [appveyor.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/appveyor.yml) workflow does not leave gaps in testing.