### PR TITLE
ci: update GitHub Actions workflows to run on node.js 20

### DIFF
--- a/.github/workflows/chrome-docker.yml
+++ b/.github/workflows/chrome-docker.yml
@@ -1,16 +1,16 @@
 name: Chrome Docker
 
-on: push
+on: [push, workflow_dispatch]
 
 jobs:
   # run Chrome inside a Docker container
   chrome:
     runs-on: ubuntu-22.04
     # https://github.com/cypress-io/cypress-docker-images
-    container: cypress/browsers:node18.12.0-chrome107
+    container: cypress/browsers:node-20.6.1-chrome-116.0.5845.187-1-ff-117.0-edge-116.0.1938.76-1
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Chrome
         uses: cypress-io/github-action@v6
         timeout-minutes: 10

--- a/.github/workflows/chrome.yml
+++ b/.github/workflows/chrome.yml
@@ -1,13 +1,13 @@
 name: Chrome
 
-on: push
+on: [push, workflow_dispatch]
 
 jobs:
   chrome:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Chrome
         uses: cypress-io/github-action@v6
         timeout-minutes: 10

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -6,21 +6,21 @@
 #
 name: Cypress parallel tests
 
-on: push
+on: [push, workflow_dispatch]
 
 jobs:
   install:
     name: Install NPM and Cypress
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # install a specific version of Node using
       # https://github.com/actions/setup-node
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       # just so we learn about available environment variables GitHub provides
       - name: Print CI env variables
@@ -79,14 +79,14 @@ jobs:
     runs-on: ubuntu-22.04
     needs: install
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # install a specific version of Node using
       # https://github.com/actions/setup-node
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       # Restore just local node_modules and the Cypress binary archives.
       - name: Cache Cypress binary
@@ -143,14 +143,14 @@ jobs:
     runs-on: ubuntu-22.04
     needs: install
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # install a specific version of Node using
       # https://github.com/actions/setup-node
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       # Restore just local node_modules and the Cypress binary archives.
       - name: Cache Cypress binary

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -2,21 +2,21 @@
 # https://docs.github.com/en/actions/using-workflows
 name: Cypress single tests
 
-on: push
+on: [push, workflow_dispatch]
 
 jobs:
   test1:
     name: Cypress test
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # install a specific version of Node using
     # https://github.com/actions/setup-node
-    - name: Use Node.js 18
+    - name: Use Node.js 20
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
 
     # just so we learn about available environment variables GitHub provides
     - name: Print env variables

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -2,14 +2,14 @@
 # in all jobs, otherwise the last version wins I believe
 name: Using Cypress GH Action
 
-on: push
+on: [push, workflow_dispatch]
 
 jobs:
   single-run:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress run
         uses: cypress-io/github-action@v6
         timeout-minutes: 10
@@ -33,7 +33,7 @@ jobs:
         machines: [1, 2, 3, 4]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
@@ -65,7 +65,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves


### PR DESCRIPTION
## Node.js 18 to 20

This PR updates several GitHub Actions CI workflows residing in the [.github/workflows](https://github.com/cypress-io/cypress-example-kitchensink/tree/master/.github/workflows) directory to run under the default Node.js `20` version as specified in [.node-version](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.node-version)

https://github.com/cypress-io/cypress-example-kitchensink/blob/277e055329a3c1a07674aeaf42d882488dcdbb78/.node-version#L1

### actions/checkout from v3 to v4

All usage of [actions/checkout](https://github.com/actions/checkout) is migrated from `v3` to `v4`.

- `actions/checkout@v3` runs under `node16`
- `actions/checkout@v4` runs under `node20`

### Docker from node18.12.0 to node-20.6.1

The Docker image [cypress/browsers](https://hub.docker.com/r/cypress/browsers/) is changed from

- `cypress/browsers:node18.12.0-chrome107` to
- `cypress/browsers:node-20.6.1-chrome-116.0.5845.187-1-ff-117.0-edge-116.0.1938.76-1`

## Addition of workflow_dispatch

For ease of use as example workflows, the event trigger [workflow_dispatch](https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_dispatch) is added to each workflow, aligning with the GitHub Actions example workflows in the [cypress-io/github-action](https://github.com/cypress-io/github-action) repo. (See GitHub documentation [Manually running a workflow](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow).)

## Verification

Manually run each GitHub Actions workflow and check for success:

### Non-recording workflows

- [x] Chrome
- [X] Chrome Docker

### Recording workflows

The following workflows record to Cypress Cloud and need special handling to test in a fork:

- [X] Cypress parallel tests
- [X] Cypress single tests
- [X] Using Cypress GH Action

These fail when tested unchanged in a fork with the error message:

> You passed the --record flag but did not provide us your Record Key.

To tests these workflows in a fork, check out the branch of this PR and modify the `projectId`

https://github.com/cypress-io/cypress-example-kitchensink/blob/277e055329a3c1a07674aeaf42d882488dcdbb78/cypress.config.js#L1

to use a personal `projectId` and create a GitHub Actions secret `DASHBOARDRECORDKEY` with the corresponding Cypress Cloud Record Key available from the Cypress Cloud Project settings UI.

## Video warnings

- The following warning message is addressed in a separate PR https://github.com/cypress-io/cypress-example-kitchensink/pull/746. They are related to previous updates from Cypress `12.x` to `13.x` and are not caused by updating to Node.js `20`.

> Cypress test
> No files were found with the provided path: cypress/videos. No artifacts will be uploaded
