### PR TITLE
ci: remove libgconf-2-4 from travis-ci workflows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,6 @@ env:
 node_js:
   - 18
 
-# if using Ubuntu 16 need this library
-# https://github.com/cypress-io/cypress-documentation/pull/1647
-addons:
-  apt:
-    packages:
-    - libgconf-2-4
-
 cache:
   # cache both npm modules and Cypress binary
   directories:

--- a/basic/.travis.yml
+++ b/basic/.travis.yml
@@ -3,13 +3,6 @@ language: node_js
 node_js:
   - 18
 
-# if using Ubuntu 16 need this library
-# https://github.com/cypress-io/cypress-documentation/pull/1647
-addons:
-  apt:
-    packages:
-    - libgconf-2-4
-
 cache:
   # cache both npm modules and Cypress binary
   directories:


### PR DESCRIPTION
This PR removes the Ubuntu/Debian package `libgconf-2-4` from the documentation-only example workflows

- [.travis.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.travis.yml)
- [basic/.travis.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/basic/.travis.yml)

The Cypress documentation [Getting Started > Installating Cypress > System requirements > Linux Prerequisites > Ubuntu/Debian](https://docs.cypress.io/guides/getting-started/installing-cypress#UbuntuDebian) no longer lists `libgconf-2-4` as a prerequisite.

## Background

- The legacy [Cypress version 3.4.1](https://docs.cypress.io/guides/references/changelog#3-4-1) was the last version to require `libgconf-2-4` (Cypress binary depends on `libgconf-2.so.4`). This version of Cypress was released on July 29, 2019.

- The package is no longer available in the latest Ubuntu release `23.10` (see [Ubuntu releases](https://wiki.ubuntu.com/Releases)). The list on [libgconf-2-4](https://packages.ubuntu.com/search?keywords=libgconf-2-4) shows the versions where it is still included.

- https://packages.debian.org/bookworm/gconf2 shows it is still included in Debian `bookworm` (`12` - `stable`) and https://tracker.debian.org/news/1450621/removed-326-8-from-unstable/ shows it has been removed from future Debian releases (`testing`)

- See also https://github.com/cypress-io/cypress-documentation/pull/5528