### PR TITLE
ci: update workflows to use Node.js 20.x LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ executors:
     resource_class: macos.x86.medium.gen2
   browsers:
     docker:
-      - image: 'cypress/browsers:node-18.15.0-chrome-111.0.5563.146-1-ff-111.0.1-edge-111.0.1661.62-1'
+      - image: 'cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1'
 
 jobs:
   win-test:

--- a/.github/workflows/chrome-docker.yml
+++ b/.github/workflows/chrome-docker.yml
@@ -7,7 +7,7 @@ jobs:
   chrome:
     runs-on: ubuntu-22.04
     # https://github.com/cypress-io/cypress-docker-images
-    container: cypress/browsers:node-20.6.1-chrome-116.0.5845.187-1-ff-117.0-edge-116.0.1938.76-1
+    container: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -18,7 +18,7 @@ jobs:
       # install a specific version of Node using
       # https://github.com/actions/setup-node
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -84,7 +84,7 @@ jobs:
       # install a specific version of Node using
       # https://github.com/actions/setup-node
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -143,7 +143,7 @@ jobs:
       # install a specific version of Node using
       # https://github.com/actions/setup-node
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -14,7 +14,7 @@ jobs:
     # install a specific version of Node using
     # https://github.com/actions/setup-node
     - name: Use Node.js 20
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 20
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ cache:
 
 # this job installs NPM dependencies and Cypress
 install:
-  image: cypress/base:18.16.1
+  image: cypress/base:20.9.0
   stage: build
 
   script:
@@ -35,7 +35,7 @@ install:
 
 # all jobs that actually run tests can use the same definition
 .job_template:
-  image: cypress/base:18.16.1
+  image: cypress/base:20.9.0
   stage: test
   script:
     # print CI environment variables for reference

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -68,7 +68,7 @@ blocks:
       # common commands that should be done before each E2E test command
       prologue:
         commands:
-          - nvm install 12
+          - nvm install 20
           - npm install -g npm
           - checkout
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   - PUPPETEER_SKIP_DOWNLOAD=1
 
 node_js:
-  - 18
+  - 20
 
 cache:
   # cache both npm modules and Cypress binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://documentation.codeship.com/pro/languages-frameworks/nodejs/
 
 # use Cypress provided image with all dependencies included
-FROM cypress/base:18.16.1
+FROM cypress/base:20.9.0
 RUN node --version
 RUN npm --version
 WORKDIR /home/node/app

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
   agent {
     // this image provides everything needed to run Cypress
     docker {
-      image 'cypress/base:18.14.1'
+      image 'cypress/base:20.9.0'
     }
   }
 

--- a/azure-ci.yml
+++ b/azure-ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - task: NodeTool@0
         inputs:
-          versionSpec: '18.x'
+          versionSpec: '20.x'
           displayName: 'Install Node.js'
 
       # NPM modules and Cypress binary should be cached

--- a/basic/.circleci/config.yml
+++ b/basic/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: cypress/base:18.16.1
+      - image: cypress/base:20.9.0
     steps:
       - checkout
       # restore folders with npm dependencies and Cypress binary

--- a/basic/.gitlab-ci.yml
+++ b/basic/.gitlab-ci.yml
@@ -13,7 +13,7 @@ cache:
     - cache/Cypress
 
 test:
-  image: cypress/base:18.16.1
+  image: cypress/base:20.9.0
   stage: test
   script:
     - npm ci

--- a/basic/.semaphore.yml
+++ b/basic/.semaphore.yml
@@ -20,7 +20,7 @@ blocks:
       jobs:
         - name: npm ci and cache
           commands:
-            - nvm install 18
+            - nvm install 20
             - npm install -g npm
             - checkout
 

--- a/basic/.travis.yml
+++ b/basic/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - 18
+  - 20
 
 cache:
   # cache both npm modules and Cypress binary

--- a/basic/Jenkinsfile
+++ b/basic/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
   agent {
     // this image provides everything needed to run Cypress
     docker {
-      image 'cypress/base:18.14.1'
+      image 'cypress/base:20.9.0'
     }
   }
 

--- a/basic/azure-ci.yml
+++ b/basic/azure-ci.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - task: NodeTool@0
         inputs:
-          versionSpec: '18.x'
+          versionSpec: '20.x'
           displayName: 'Install Node.js'
 
       # NPM modules and Cypress binary should be cached

--- a/basic/buildspec.yml
+++ b/basic/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: latest
+      nodejs: 20
     commands:
       # Set COMMIT_INFO variables to send Git specifics to Cypress Cloud when recording
       # https://docs.cypress.io/guides/continuous-integration/introduction#Git-information

--- a/basic/codeship-pro/Dockerfile
+++ b/basic/codeship-pro/Dockerfile
@@ -2,7 +2,7 @@
 # https://documentation.codeship.com/pro/languages-frameworks/nodejs/
 
 # use Cypress provided image with all dependencies included
-FROM cypress/base:18.16.1
+FROM cypress/base:20.9.0
 RUN node --version
 RUN npm --version
 WORKDIR /home/node/app

--- a/buddy.yml
+++ b/buddy.yml
@@ -8,7 +8,7 @@
       type: "BUILD"
       working_directory: "/buddy/cypress-example-kitchensink"
       docker_image_name: "cypress/base"
-      docker_image_tag: "18.14.1"
+      docker_image_tag: "20.9.0"
       execute_commands:
         - "npm install --force"
         - "npm run cy:verify"


### PR DESCRIPTION
This PR updates CI workflows to use Node.js `20.x`, codename 'Iron'.

[Node.js v20.9.0](https://nodejs.org/en/blog/release/v20.9.0) became the Active LTS version on Oct 24, 2023.

Docker images are transitioned to:

- [cypress/base](https://hub.docker.com/r/cypress/base)
    `cypress/base:20.9.0`
- [cypress/browsers](https://hub.docker.com/r/cypress/browsers/)
    `cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1`

GitHub actions are updated to use [actions/setup-node@v4](https://github.com/actions/setup-node), which is the version compatible with `node20`.

## Background

Node.js transitioned version `18.x` to LTS maintenance status and version `20.x` to active LTS status on October 24, 2023 (see [Node.js release schedule](https://github.com/nodejs/release#release-schedule) and [Node v20.9.0 (LTS)](https://nodejs.org/en/blog/release/v20.9.0) announcement).
