### PR TITLE
chore: remove unused/unnecessary deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,6 @@ jobs:
             - C:\Users\circleci\AppData\Local\Cypress\Cache
             - C:\Users\circleci\AppData\Roaming\npm-cache
 
-      # if you want to test execa's behavior on Windows
-      # - run: node ./scripts/test-execa
-
       - run:
           name: 'Start server'
           command: npm run start
@@ -85,9 +82,6 @@ jobs:
             - C:\Users\circleci\AppData\Local\Cypress\Cache
             - C:\Users\circleci\AppData\Roaming\npm-cache
 
-      # if you want to test execa's behavior on Windows
-      # - run: node ./scripts/test-execa
-
       - run:
           name: 'Start server'
           command: npm run start
@@ -125,9 +119,6 @@ jobs:
             # could not use environment variables for some reason
             - C:\Users\circleci\AppData\Local\Cypress\Cache
             - C:\Users\circleci\AppData\Roaming\npm-cache
-
-      # if you want to test execa's behavior on Windows
-      # - run: node ./scripts/test-execa
 
       - run:
           name: 'Start server'

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
       },
       "devDependencies": {
         "@bahmutov/print-env": "1.3.0",
-        "colon-names": "1.0.0",
         "cypress": "13.6.1",
         "eslint": "8.56.0",
         "eslint-plugin-cypress": "2.15.1",
@@ -2134,22 +2133,6 @@
         "qs": "^6.5.2",
         "raw-body": "^2.3.3",
         "type-is": "^1.6.16"
-      }
-    },
-    "node_modules/colon-names": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/colon-names/-/colon-names-1.0.0.tgz",
-      "integrity": "sha512-9KSE6zbPFIMLUOTfeZyDyS8RUfpgo/1l9FD4ACJjzwz5mKBFuBspEed5lL7CXZRxSrba0YH/pMEASRtMj3O71Q==",
-      "dev": true,
-      "dependencies": {
-        "check-more-types": "2.24.0",
-        "lazy-ass": "1.6.0"
-      },
-      "bin": {
-        "colon-names": "bin/colon-names.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/color-convert": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "eslint-plugin-cypress": "2.15.1",
         "eslint-plugin-json-format": "2.0.1",
         "eslint-plugin-mocha": "10.2.0",
-        "execa": "2.1.0",
         "globby": "11.1.0",
         "husky": "8.0.3",
         "netlify-plugin-cypress": "2.2.1",
@@ -3541,26 +3540,6 @@
       "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
       "dev": true
     },
-    "node_modules/execa": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
-      "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^3.0.0",
-        "onetime": "^5.1.0",
-        "p-finally": "^2.0.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": "^8.12.0 || >=9.7.0"
-      }
-    },
     "node_modules/executable": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
@@ -6783,18 +6762,6 @@
         "which": "bin/which"
       }
     },
-    "node_modules/npm-run-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
-      "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/@colors/colors": {
       "version": "1.5.0",
       "dev": true,
@@ -9383,15 +9350,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/p-finally": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/p-is-promise": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "eslint-plugin-cypress": "2.15.1",
     "eslint-plugin-json-format": "2.0.1",
     "eslint-plugin-mocha": "10.2.0",
-    "execa": "2.1.0",
     "globby": "11.1.0",
     "husky": "8.0.3",
     "netlify-plugin-cypress": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@bahmutov/print-env": "1.3.0",
-    "colon-names": "1.0.0",
     "cypress": "13.6.1",
     "eslint": "8.56.0",
     "eslint-plugin-cypress": "2.15.1",

--- a/scripts/test-execa.js
+++ b/scripts/test-execa.js
@@ -1,5 +1,0 @@
-const execa = require('execa')
-
-execa('echo Hello', {
-  shell: true,
-}).then(console.log)


### PR DESCRIPTION
- Close https://github.com/cypress-io/cypress-example-kitchensink/pull/773

Execa isn't used - it's referenced in commented out code in Circle.yml for debugging purposes (I suppose?) Removing the dep so we don't have to keep up with dep and dep updates.

colon-names is just not really a necessary dep. If enforces npm script formatting.