### PR TITLE
ci(deps): update actions/cache to v4

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -35,7 +35,7 @@ jobs:
       # we use exact restore key to avoid NPM module snowballing
       # https://glebbahmutov.com/blog/do-not-let-npm-cache-snowball/
       - name: Cache central NPM modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
@@ -45,7 +45,7 @@ jobs:
       # we use the exact restore key to avoid Cypress binary snowballing
       # https://glebbahmutov.com/blog/do-not-let-cypress-cache-snowball/
       - name: Cache Cypress binary
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
@@ -54,7 +54,7 @@ jobs:
 
       # Cache local node_modules to pass to testing jobs
       - name: Cache local node_modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
@@ -90,7 +90,7 @@ jobs:
 
       # Restore just local node_modules and the Cypress binary archives.
       - name: Cache Cypress binary
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
@@ -98,7 +98,7 @@ jobs:
             cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Cache local node_modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
@@ -149,7 +149,7 @@ jobs:
 
       # Restore just local node_modules and the Cypress binary archives.
       - name: Cache Cypress binary
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
@@ -157,7 +157,7 @@ jobs:
             cypress-${{ runner.os }}-cypress-${{ github.ref }}-
 
       - name: Cache local node_modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -29,13 +29,13 @@ jobs:
     # and saved automatically after the entire workflow successfully finishes.
     # See https://github.com/actions/cache
     - name: Cache node modules
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
     - name: Cache Cypress binary
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/Cypress
         key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
- This PR follows on from https://github.com/cypress-io/cypress-example-kitchensink/pull/752 and updates the GitHub-provided JavaScript [actions/cache](https://github.com/actions/cache) to `v4` for compatibility with `node20`.

## Issue

The following workflows output a deprecation warning when run on GitHub:

- [single.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/single.yml)
- [parallel.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/parallel.yml)

Deprecation warning:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

- https://github.com/cypress-io/cypress-example-kitchensink/pull/780 deals with updating `actions/upload-artifact@v3`. This PR is for the deprecation issue with `actions/cache@v3`

## Changes

### actions/cache from v3 to v4

All usage of [actions/cache](https://github.com/actions/cache) is migrated from `v3` to `v4`.

- `actions/cache@v3` runs under `node16`
- `actions/cache@v4` runs under `node20`


## Verification

Manually run each GitHub Actions workflow and check for success. The following workflows record to Cypress Cloud and need special handling to test in a fork:

- [ ] [Cypress single tests](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/single.yml)
- [ ] [Cypress parallel tests](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/parallel.yml)

These fail when tested unchanged in a fork with the error message:

> You passed the --record flag but did not provide us your Record Key.

To tests these workflows in a fork, check out the branch of this PR and modify the `projectId`

https://github.com/cypress-io/cypress-example-kitchensink/blob/277e055329a3c1a07674aeaf42d882488dcdbb78/cypress.config.js#L2

to use a personal `projectId` and create a GitHub Actions secret `DASHBOARDRECORDKEY` with the corresponding Cypress Cloud Record Key available from the Cypress Cloud Project settings UI.
