### PR TITLE
ci: use containers matrix name in github actions workflow

### DIFF
--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -27,10 +27,14 @@ jobs:
       # https://github.com/cypress-io/github-action/issues/48
       fail-fast: false
       matrix:
-        # run 4 copies of the current job in parallel
-        # the actual items in the array do not matter
-        # we just need to "force" GitHub CI to create 4 jobs
-        machines: [1, 2, 3, 4]
+        # Run 4 copies of the current job in parallel.
+        # The name of the array (containers) and
+        # the actual items in the array (1, 2, 3, 4) do not matter.
+        # Based on the array, GitHub Actions will create
+        # 4 independently running parallel jobs
+        # (see https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs).
+        # Cypress Cloud load-balances the Cypress tests across the GitHub Actions jobs.
+        containers: [1, 2, 3, 4]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -61,7 +65,7 @@ jobs:
         # run 2 copies of the current job in parallel
         # and they will load balance all specs
         os: ['ubuntu-22.04', 'windows-latest', 'macos-latest']
-        machines: [1, 2]
+        containers: [1, 2]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR changes the GitHub Actions matrix variable name from `machines` to `containers` in the workflow [using-action.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/using-action.yml) for consistency with the [Cypress documentation (docs.cypress.io)](https://docs.cypress.io/) and the [Cypress GitHub Action repo (github.com/cypress-io/github-action)](https://github.com/cypress-io/github-action). It also expands on the in-line explanation about the matrix array `containers`.

## Reason for change

Although the workflow previously explained that the items in the matrix did not matter, it has led to some confusion in new users concerning the matrix variable name `machines` used by the example GitHub Action workflow [using-action.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/using-action.yml):

```
    strategy:
      # when one test fails, DO NOT cancel the other
      # containers, because this will kill Cypress processes
      # leaving the Cypress Cloud dashboard hanging ...
      # https://github.com/cypress-io/github-action/issues/48
      fail-fast: false
      matrix:
        # run 4 copies of the current job in parallel
        # the actual items in the array do not matter
        # we just need to "force" GitHub CI to create 4 jobs
        machines: [1, 2, 3, 4]
```

The [Cypress documentation (docs.cypress.io)](https://docs.cypress.io/) and the [Cypress GitHub Action repo (github.com/cypress-io/github-action)](https://github.com/cypress-io/github-action) consistently use the variable

`containers`

as the name of the matrix array which defines how many parallel jobs are run when recording into Cypress Cloud.

The matrix variable name `containers` is simply a dummy name, which does not affect how the workflow runs, since the variable name is not used in any substitution. For comparison, in the job `parallel-runs-across-platforms`, the matrix variable name `os` and the array contents `os: ['ubuntu-22.04', 'windows-latest', 'macos-latest']` **are** significant and these **are** used in substitution.

### References

- GitHub documentation [Using a matrix for your jobs](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs)
- Cypress [Continuous Integration > GitHub Actions](https://docs.cypress.io/guides/continuous-integration/github-actions)
- Cypress GitHub Action [README > Parallel](https://github.com/cypress-io/github-action/blob/master/README.md#parallel)
- Cypress GitHub Action workflows
    - [example-custom-ci-build-id.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-custom-ci-build-id.yml)
    - [example-recording.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-recording.yml)
