### PR TITLE
fix: qualify E2E testing scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Kitchen Sink [![renovate-app badge][renovate-badge]][renovate-app] [![semantic-release][semantic-image] ][semantic-url]
 
-This is an example app used to showcase [Cypress.io](https://www.cypress.io/) testing. The application uses every API command in Cypress for demonstration purposes. Additionally this example app is configured to run tests in various CI platforms. The [tests](https://github.com/cypress-io/cypress-example-kitchensink/tree/master/cypress/e2e) are also heavily commented. For a full reference of our documentation, go to [docs.cypress.io](https://docs.cypress.io/).
+This is an example app used to showcase [Cypress.io](https://www.cypress.io/) End-to-End (E2E) testing. The application demonstrates the use of most [Cypress API commands](https://on.cypress.io/api). Additionally this example app is configured to run E2E tests in various CI platforms. The [tests](https://github.com/cypress-io/cypress-example-kitchensink/tree/master/cypress/e2e) are also heavily commented.
 
-To see the kitchen sink application, visit [example.cypress.io](https://example.cypress.io/).
+To see the kitchen sink application, and to view the [Cypress API commands](https://on.cypress.io/api) demonstrated by the app, visit [example.cypress.io](https://example.cypress.io/).
+
+For a full reference of our documentation, go to [docs.cypress.io](https://docs.cypress.io/).
+
+For an example payment application demonstrating real-world usage of Cypress.io End-to-End (E2E) testing, go to the [cypress-io/cypress-realworld-app](https://github.com/cypress-io/cypress-realworld-app) repository.
 
 [renovate-badge]: https://img.shields.io/badge/renovate-app-blue.svg
 [renovate-app]: https://renovateapp.com/

--- a/app/index.html
+++ b/app/index.html
@@ -63,7 +63,7 @@
   <div class="banner">
     <div class="container">
       <h1>Kitchen Sink</h1>
-      <p>This is an example app used to showcase <a href="https://www.cypress.io" target="_blank">Cypress.io</a> testing. For a full reference of our documentation, go to <a href="https://docs.cypress.io" target="_blank">docs.cypress.io</a>
+      <p>This is an example app used to showcase <a href="https://www.cypress.io" target="_blank">Cypress.io</a> End-to-End (E2E) testing. For a full reference of our documentation, go to <a href="https://docs.cypress.io" target="_blank">docs.cypress.io</a>
       </p>
     </div>
   </div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cypress-example-kitchensink",
   "version": "0.0.0-development",
-  "description": "This is an example app used to showcase Cypress.io testing. For a full reference of our documentation, go to https://docs.cypress.io",
+  "description": "This is an example app used to showcase Cypress.io End-to-End (E2E) testing. For a full reference of our documentation, go to https://docs.cypress.io",
   "main": "index.js",
   "files": [
     "app",


### PR DESCRIPTION
- closes #796

## Issue

The repo description does not take account of the addition of Component Testing to the previously available End-to-End Testing. `cypress-example-kitchensink` provides for E2E Testing only, not Component Testing.

The repo also claims that "every API command in Cypress" is tested, which is not completely true.

## Changes

The following locations are updated:

- [README](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/README.md)
- [package.json](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/package.json)
- [app/index.html](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/app/index.html)

1. The testing is qualified as "Cypress.io End-to-End (E2E) testing"
2. A link to [cypress-io/cypress-realworld-app](https://github.com/cypress-io/cypress-realworld-app) is added to the [README](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/README.md). ""

