### PR TITLE
chore(deps): refresh start-server-and-test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -865,9 +865,9 @@
       }
     },
     "node_modules/@sideway/address": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
       "dev": true,
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
@@ -1326,12 +1326,12 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -3534,9 +3534,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true,
       "funding": [
         {
@@ -4536,14 +4536,14 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.12.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.0.tgz",
-      "integrity": "sha512-HSLsmSmXz+PV9PYoi3p7cgIbj06WnEBNT28n+bbBNcPZXZFqCzzvGqpTBPujx/Z0nh1+KNQPDrNgdmQ8dq0qYw==",
+      "version": "17.12.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.2.tgz",
+      "integrity": "sha512-RonXAIzCiHLc8ss3Ibuz45u28GOsWE1UpfDXLbN/9NKbL4tCJf8TWYVKsoYuuh+sAUt7fsSNpA+r2+TBA6Wjmw==",
       "dev": true,
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
         "@hapi/topo": "^5.1.0",
-        "@sideway/address": "^4.1.4",
+        "@sideway/address": "^4.1.5",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }


### PR DESCRIPTION
## Issue

`npm audit` shows a vulnerability from `follow-redirects@1.15.5`

```test
follow-redirects  <=1.15.5
Severity: moderate
follow-redirects' Proxy-Authorization header kept across hosts - https://github.com/advisories/GHSA-cxjh-pqwp-8mfp
fix available via `npm audit fix`
node_modules/follow-redirects
```

`follow-redirects` is a dependency of `start-server-and-test`

```text
└─┬ start-server-and-test@2.0.3
  └─┬ wait-on@7.2.0
    └─┬ axios@1.6.7
      └── follow-redirects@1.15.5
```

## Change

`start-server-and-test@2.0.3` is uninstalled and reinstalled with npm.

```shell
npm uninstall start-server-and-test
npm install start-server-and-test -D -E
```

This refreshes dependencies `axios` and `follow-redirects`, remediating the moderate vulnerability from `follow-redirects@1.15.5` by updating to `follow-redirects@1.15.6`. (It leaves the dependencies in a robuster state than if `npm audit fix` were to be executed which would only update `follow-redirects`, not `axios`.)

`npm ls follow-redirects` after change shows:

```text
└─┬ start-server-and-test@2.0.3
  └─┬ wait-on@7.2.0
    └─┬ axios@1.6.8
      └── follow-redirects@1.15.6
```

## Verification

Execute `npm audit` and check that there is no mention of `follow-directs`.
