### PR TITLE
ci: cause skipped tests linting error

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,7 @@
   "rules": {
     "indent": ["error", 2, { "SwitchCase": 1, "MemberExpression": "off" }],
     "mocha/no-exclusive-tests": "error",
+    "mocha/no-skipped-tests": "error",
     "mocha/no-mocha-arrows": "off"
   }
 }


### PR DESCRIPTION
## Issue

[eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha) is configured inconsistently in this repo regarding the rules:

- [mocha/no-exclusive-tests](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/docs/rules/no-exclusive-tests.md) to warn about the use of  `describe.only`, `it.only`, etc. - configured to `error`
- [mocha/no-skipped-tests](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/docs/rules/no-skipped-tests.md) to warn about the use of `describe.skip`, `it.skip`, etc. - configured per `plugin:mocha/recommended` for `warn` only (see [Rules table](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/README.md#rules)) for this plugin.

Since it is undesirable to have `.only` or `.skip` in the example test specs, both should be configured to `error` on linting.

## Change

Add [mocha/no-skipped-tests](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/docs/rules/no-skipped-tests.md) `error` to the configuration in [.eslintrc](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.eslintrc).

```json
 "rules": {
    ...
    "mocha/no-skipped-tests": "error",
    ...
  }
```

## Verification

Temporarily modify the file `cypress/e2e/2-advanced-examples/actions.cy.js` to add an exclusive test and a skipped test:
- Change `context` to `context.only`
- Change the first occurence of `it` to `it.skip`

and execute:

```shell
npm ci
npx eslint cypress
```

confirm that linting errors (no warnings) are reported:

```text
$ npx eslint cypress

   3:9  error  Unexpected exclusive mocha test  mocha/no-exclusive-tests
  10:6  error  Unexpected skipped mocha test    mocha/no-skipped-tests

✖ 2 problems (2 errors, 0 warnings)
```
