### PR TITLE
chore(deps): update serve to 14.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "npm-run-all2": "^5.0.0",
-        "serve": "14.2.1"
+        "serve": "14.2.2"
       },
       "devDependencies": {
         "@bahmutov/print-env": "1.3.0",
@@ -9775,12 +9775,12 @@
       }
     },
     "node_modules/serve": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.1.tgz",
-      "integrity": "sha512-48er5fzHh7GCShLnNyPBRPEjs2I6QBozeGr02gaacROiyS/8ARADlj595j39iZXAqBbJHH/ivJJyPRWY9sQWZA==",
+      "version": "14.2.2",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.2.tgz",
+      "integrity": "sha512-MktTGv3ooijGxd67iQVocNdiHaOdNnEApGj7At4qHUN44XDaLFfrqbEtj5mXf+QNqyig/VdHYMRTXWRQj6TEbw==",
       "dependencies": {
         "@zeit/schemas": "2.29.0",
-        "ajv": "8.11.0",
+        "ajv": "8.12.0",
         "arg": "5.0.2",
         "boxen": "7.0.0",
         "chalk": "5.0.1",
@@ -9854,9 +9854,9 @@
       "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ=="
     },
     "node_modules/serve/node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "homepage": "https://github.com/cypress-io/cypress-example-kitchensink#readme",
   "dependencies": {
     "npm-run-all2": "^5.0.0",
-    "serve": "14.2.1"
+    "serve": "14.2.2"
   },
   "devDependencies": {
     "@bahmutov/print-env": "1.3.0",


### PR DESCRIPTION
## Issue

Starting the server, logs the following information:

```text
 cypress-example-kitchensink@0.0.0-development start
> node ./scripts/start.js

Running "serve --listen 8080 --no-request-logging --no-clipboard"...
 UPDATE  The latest version of `serve` is 14.2.2
```

## Change

Bumps the version of npm module [serve](https://www.npmjs.com/package/serve) from `14.2.1` to [14.2.2](https://github.com/vercel/serve/releases/tag/14.2.2) (latest).

## Verification

Ubuntu `22.04.4` LTS, Node.js `20.12.2`

```bash
npm ci
npm run local:run
```

1. The tests should be successful.
1. The information text "UPDATE AVAILABLE The latest version of `serve` is 14.2.2" should **not** appear.
