### PR TITLE
chore: bump CircleCI resource class from intel to m1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
   mac:
     macos:
       xcode: "14.3.1"
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
   browsers:
     docker:
       - image: 'cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1'


### PR DESCRIPTION
Brownout today that highlighted the deprecated resource class is in use: https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718