### PR TITLE
chore(deps): migrate to eslint stylistic 1.7.2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,7 @@
     "plugin:mocha/recommended"
   ],
   "plugins": [
+    "@stylistic/js",
     "cypress",
     "mocha"
   ],
@@ -13,7 +14,7 @@
     "node": true
   },
   "rules": {
-    "indent": ["error", 2, { "SwitchCase": 1, "MemberExpression": "off" }],
+    "@stylistic/js/indent": ["error", 2, { "SwitchCase": 1, "MemberExpression": "off" }],
     "mocha/no-exclusive-tests": "error",
     "mocha/no-skipped-tests": "error",
     "mocha/no-mocha-arrows": "off"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@bahmutov/print-env": "1.3.0",
+        "@stylistic/eslint-plugin-js": "1.7.2",
         "cypress": "13.8.1",
         "eslint": "8.57.0",
         "eslint-plugin-cypress": "3.0.2",
@@ -1190,6 +1191,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@stylistic/eslint-plugin-js": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.7.2.tgz",
+      "integrity": "sha512-ZYX7C5p7zlHbACwFLU+lISVh6tdcRP/++PWegh2Sy0UgMT5kU0XkPa2tKWEtJYzZmPhJxu9LxbnWcnE/tTwSDQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "^8.56.8",
+        "acorn": "^8.11.3",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@types/eslint": {
+      "version": "8.56.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+      "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
     "node_modules/@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -1199,6 +1235,12 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "@bahmutov/print-env": "1.3.0",
+    "@stylistic/eslint-plugin-js": "1.7.2",
     "cypress": "13.8.1",
     "eslint": "8.57.0",
     "eslint-plugin-cypress": "3.0.2",


### PR DESCRIPTION
## Issue

The ESLint rule [indent](https://eslint.org/docs/latest/rules/indent) was **deprecated** in ESLint `v8.53.0`. The ESlint documentation suggests to use the [corresponding rule](https://eslint.style/rules/js/indent) in [`@stylistic/eslint-plugin-js`](https://eslint.style/packages/js).

This repo uses ESLint `v8.57.0` and so the deprecation already applies.

## Change

1. The npm module [@stylistic/eslint-plugin-js](https://www.npmjs.com/package/@stylistic/eslint-plugin-js) is added using the release [@stylistic/eslint-plugin-js@1.7.2](https://github.com/eslint-community/eslint-stylistic/releases/tag/v1.7.2).
2. The [.eslintrc](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.eslintrc) configuration is changed:
   1. `@stylistic/js` added to `plugins`
   2. The `indent` rule is changed from
    https://github.com/cypress-io/cypress-example-kitchensink/blob/c06177dadc9063e3a0f91bfb35a225a1cde94a91/.eslintrc#L16
    to
    >     "@stylistic/js/indent": ["error", 2, { "SwitchCase": 1, "MemberExpression": "off" }]

This is a refactor since the functionality remains the same, only the underlying tools are changed.

## Verification

```shell
npm ci
npm run lint
```

## Reference

- [@stylistic/js/indent](https://eslint.style/rules/js/indent#indent)
