### PR TITLE
test: replace and activate json linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,12 +2,14 @@
   "extends": [
     "eslint:recommended",
     "plugin:cypress/recommended",
-    "plugin:mocha/recommended"
+    "plugin:mocha/recommended",
+    "plugin:jsonc/recommended-with-json"
   ],
   "plugins": [
     "@stylistic/js",
     "cypress",
-    "mocha"
+    "mocha",
+    "jsonc"
   ],
   "env": {
     "cypress/globals": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "cypress": "13.8.1",
         "eslint": "8.57.0",
         "eslint-plugin-cypress": "3.0.2",
-        "eslint-plugin-json-format": "2.0.1",
+        "eslint-plugin-jsonc": "2.15.1",
         "eslint-plugin-mocha": "10.4.3",
         "globby": "11.1.0",
         "husky": "9.0.6",
@@ -198,18 +198,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.23.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
-      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
-      "dev": true,
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@bahmutov/print-env": {
@@ -1226,26 +1214,10 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
-    "node_modules/@types/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
-    },
-    "node_modules/@types/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true
     },
     "node_modules/@types/minimist": {
@@ -1259,6 +1231,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.10.tgz",
       "integrity": "sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2599,30 +2572,6 @@
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
     },
-    "node_modules/detect-indent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
-      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/detect-newline": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
-      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/diff-match-patch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
-      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
-      "dev": true
-    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2935,6 +2884,21 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-compat-utils": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.0.tgz",
+      "integrity": "sha512-dc6Y8tzEcSYZMHa+CMPLi/hyo1FzNeonbhJL7Ol0ccuKQkwopJcJBA9YL/xmMTLU1eKigXo9vj9nALElWYSowg==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
     "node_modules/eslint-plugin-cypress": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-3.0.2.tgz",
@@ -2947,26 +2911,28 @@
         "eslint": ">=7 <9"
       }
     },
-    "node_modules/eslint-plugin-json-format": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-json-format/-/eslint-plugin-json-format-2.0.1.tgz",
-      "integrity": "sha512-eWT0sNqIEYzKqbej2dvz+/oQ4JQxthE3i+izjInIdfbsPfVgBtiWbmagkgKStje0LJqo9FATx1LWl6xcuxqsBQ==",
+    "node_modules/eslint-plugin-jsonc": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.15.1.tgz",
+      "integrity": "sha512-PVFrqIJa8BbM/e828RSn0SwB/Z5ye+2LDuy2XqG6AymNgPsfApRRcznsbxP7VrjdLEU4Nb+g9n/d6opyp0jp9A==",
       "dev": true,
       "dependencies": {
-        "common-tags": "^1.8.0",
-        "debug": "^4.1.1",
-        "diff-match-patch": "^1.0.4",
-        "json-fixer": "^1.3.2",
-        "line-column": "^1.0.2",
-        "lodash": "^4.17.15",
-        "minimatch": "^3.0.4",
-        "sort-package-json": "^1.22.1"
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "eslint-compat-utils": "^0.5.0",
+        "espree": "^9.6.1",
+        "graphemer": "^1.4.0",
+        "jsonc-eslint-parser": "^2.0.4",
+        "natural-compare": "^1.4.0",
+        "synckit": "^0.6.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
       },
       "peerDependencies": {
-        "eslint": ">= 3.2.1"
+        "eslint": ">=6.0.0"
       }
     },
     "node_modules/eslint-plugin-mocha": {
@@ -3529,15 +3495,6 @@
       "dev": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "node_modules/git-hooks-list": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-1.0.3.tgz",
-      "integrity": "sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/fisker/git-hooks-list?sponsor=1"
       }
     },
     "node_modules/git-log-parser": {
@@ -4158,18 +4115,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
-    "node_modules/isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
-      "dev": true,
-      "dependencies": {
-        "isarray": "1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -4243,20 +4188,6 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
     },
-    "node_modules/json-fixer": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/json-fixer/-/json-fixer-1.6.15.tgz",
-      "integrity": "sha512-TuDuZ5KrgyjoCIppdPXBMqiGfota55+odM+j2cQ5rt/XKyKmqGB3Whz1F8SN8+60yYGy/Nu5lbRZ+rx8kBIvBw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "chalk": "^4.1.2",
-        "pegjs": "^0.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -4291,6 +4222,24 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
+    },
+    "node_modules/jsonc-eslint-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.0.tgz",
+      "integrity": "sha512-WYDyuc/uFcGp6YtM2H0uKmUwieOuzeE/5YocFJLnLfclZ4inf3mRn8ZVy1s7Hxji7Jxm6Ss8gqpexD/GlKoGgg==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.5.0",
+        "eslint-visitor-keys": "^3.0.0",
+        "espree": "^9.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      }
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -4382,16 +4331,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/line-column": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/line-column/-/line-column-1.0.2.tgz",
-      "integrity": "sha512-Ktrjk5noGYlHsVnYWh62FLVs4hTb8A3e+vucNZMgPeAOITdshMSgv4cCZQeRDjm7+goqmo6+liZwTXo+U3sVww==",
-      "dev": true,
-      "dependencies": {
-        "isarray": "^1.0.0",
-        "isobject": "^2.0.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -8641,18 +8580,6 @@
         "through": "~2.3"
       }
     },
-    "node_modules/pegjs": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
-      "integrity": "sha512-qI5+oFNEGi3L5HAxDwN2LA4Gg7irF70Zs25edhjld9QemOgp0CbvMtbFcMvFtEo1OityPrcCzkQFB8JP/hxgow==",
-      "dev": true,
-      "bin": {
-        "pegjs": "bin/pegjs"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -9238,12 +9165,6 @@
       "dependencies": {
         "esprima": "~4.0.0"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
     },
     "node_modules/registry-auth-token": {
       "version": "5.0.2",
@@ -10108,57 +10029,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/sort-object-keys": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
-      "integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==",
-      "dev": true
-    },
-    "node_modules/sort-package-json": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.57.0.tgz",
-      "integrity": "sha512-FYsjYn2dHTRb41wqnv+uEqCUvBpK3jZcTp9rbz2qDTmel7Pmdtf+i2rLaaPMRZeSVM60V3Se31GyWFpmKs4Q5Q==",
-      "dev": true,
-      "dependencies": {
-        "detect-indent": "^6.0.0",
-        "detect-newline": "3.1.0",
-        "git-hooks-list": "1.0.3",
-        "globby": "10.0.0",
-        "is-plain-obj": "2.1.0",
-        "sort-object-keys": "^1.1.3"
-      },
-      "bin": {
-        "sort-package-json": "cli.js"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/globby": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.0.tgz",
-      "integrity": "sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==",
-      "dev": true,
-      "dependencies": {
-        "@types/glob": "^7.1.1",
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.0.3",
-        "glob": "^7.1.3",
-        "ignore": "^5.1.1",
-        "merge2": "^1.2.3",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10466,6 +10336,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.6.2.tgz",
+      "integrity": "sha512-Vhf+bUa//YSTYKseDiiEuQmhGCoIF3CVBhunm3r/DQnYiGT4JssmnKQc44BIyOZRK2pKjXXAgbhfmbeoC9CJpA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
@@ -10693,7 +10575,8 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "cypress": "13.8.1",
     "eslint": "8.57.0",
     "eslint-plugin-cypress": "3.0.2",
-    "eslint-plugin-json-format": "2.0.1",
+    "eslint-plugin-jsonc": "2.15.1",
     "eslint-plugin-mocha": "10.4.3",
     "globby": "11.1.0",
     "husky": "9.0.6",


### PR DESCRIPTION
## Issue

- The current linting setup does not catch any `json` errors in the examples.

- [eslint-plugin-json-format](https://www.npmjs.com/package/eslint-plugin-json-format) is installed, however it is not configured in [.eslintrc](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.eslintrc) to be active in terms of the plugin itself, nor the filename extension `*.json`.

## Steps to reproduce

Ubuntu `22.04.4` LTS, Node.js `20.12.2` LTS

Execute

```shell
git clone https://github.com/cypress-io/cypress-example-kitchensink
cd cypress-example-kitchensink
npm ci
npm run lint
```

and confirm that no errors are reported.

Now temporarily delete the end-of-line commas in [cypress/fixtures/example.json](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/fixtures/example.json) and save the file.

Execute again

```shell
npm run lint
```

and note that no errors are reported even though the JSON file above is incorrect.

## JSON Plugins

- [eslint-plugin-json-format](https://www.npmjs.com/package/eslint-plugin-json-format) was last published 5 years ago and it seems unlikely that it will be maintained in the future, or that it will offer ESLint `9.x` compatibility with flat config file support.

- [eslint-plugin-jsonc](https://www.npmjs.com/package/eslint-plugin-jsonc) is a maintained plugin which provides linting for JSON, JSONC and JSON5 files. It is compatible with ESLint >= 6. It provides legacy and flat config file support.

## Options

Correcting the configuration for [eslint-plugin-json-format](https://www.npmjs.com/package/eslint-plugin-json-format)  would only be a short-term solution. [eslint-plugin-jsonc](https://www.npmjs.com/package/eslint-plugin-jsonc) is used instead.

## Change

1. Uninstall [eslint-plugin-json-format](https://www.npmjs.com/package/eslint-plugin-json-format)
2. Install [eslint-plugin-jsonc](https://www.npmjs.com/package/eslint-plugin-jsonc)
3. Add `plugin:jsonc/recommended-with-json` configuration to `extends` of [.eslintrc](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.eslintrc)
