### PR TITLE
fix: clean unused eslint disables

### DIFF
--- a/cypress/e2e/2-advanced-examples/connectors.cy.js
+++ b/cypress/e2e/2-advanced-examples/connectors.cy.js
@@ -9,7 +9,6 @@ context('Connectors', () => {
     // https://on.cypress.io/each
     cy.get('.connectors-each-ul>li')
       .each(($el, index, $list) => {
-        // eslint-disable-next-line no-console
         console.log($el, index, $list)
       })
   })

--- a/cypress/e2e/2-advanced-examples/cypress_api.cy.js
+++ b/cypress/e2e/2-advanced-examples/cypress_api.cy.js
@@ -20,7 +20,6 @@ context('Cypress APIs', () => {
         method = method || 'log'
 
         // log the subject to the console
-        // eslint-disable-next-line no-console
         console[method]('The subject is', subject)
 
         // whatever we return becomes the new subject

--- a/cypress/e2e/2-advanced-examples/navigation.cy.js
+++ b/cypress/e2e/2-advanced-examples/navigation.cy.js
@@ -39,8 +39,6 @@ context('Navigation', () => {
     // https://on.cypress.io/visit
 
     // Visit any sub-domain of your current domain
-
-    /* eslint-disable no-unused-vars */
     // Pass options to the visit
     cy.visit('http://localhost:8080/commands/navigation', {
       timeout: 50000, // increase total time for the visit to resolve
@@ -53,6 +51,5 @@ context('Navigation', () => {
         expect(typeof contentWindow === 'object').to.be.true
       },
     })
-    /* eslint-enable no-unused-vars */
   })
 })

--- a/cypress/e2e/2-advanced-examples/spies_stubs_clocks.cy.js
+++ b/cypress/e2e/2-advanced-examples/spies_stubs_clocks.cy.js
@@ -25,7 +25,6 @@ context('Spies, Stubs, and Clock', () => {
        * @param x {any}
       */
       foo (x) {
-        /* eslint-disable-next-line no-console */
         console.log('obj.foo called with', x)
       },
     }
@@ -54,7 +53,6 @@ context('Spies, Stubs, and Clock', () => {
        * @param b {string}
       */
       foo (a, b) {
-        // eslint-disable-next-line no-console
         console.log('a', a, 'b', b)
       },
     }


### PR DESCRIPTION
## Issue

ESLint `9.x` identifies usages in the repo of unnecessary ESLint rule disables.

This affects the following instances:

`/* eslint-disable-next-line no-console */` in

- [cypress/e2e/2-advanced-examples/connectors.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/2-advanced-examples/connectors.cy.js)
- [cypress/e2e/2-advanced-examples/cypress_api.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/2-advanced-examples/cypress_api.cy.js)
- [cypress/e2e/2-advanced-examples/spies_stubs_clocks.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/2-advanced-examples/spies_stubs_clocks.cy.js)

The ESLint [no-console](https://eslint.org/docs/latest/rules/no-console) rule does not belong to the set of recommended rules in ESLint `8.x` or `9.x` and so disabling it in-line was not necessary.

`/* eslint-disable no-unused-vars */` in

- [cypress/e2e/2-advanced-examples/navigation.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/2-advanced-examples/navigation.cy.js)

ESLint finds no unused variables in the marked section.

## Process

By temporarily updating to ESLint `9.x`, unnecessary rule disables are identified and automatically removed by `eslint --fix`

Run ESLint `9.x`:

```shell
npm ci
npm install eslint@9 --force
npm run lint
```

Revert to ESLint `8.x` and check that linting still works:

```shell
git restore package.json package-lock.json
npm ci
npm run lint
```

## Changes

- Automatic fixes from ESLint are applied.
- Additionally associated left-over blank lines are removed.

This prepares the Cypress test specs so that they will pass linting when the repo is migrated to ESLint `9.x`.

## Verification

On Ubuntu `22.04.4` LTS, Node.js `v20.12.2` LTS

```shell
npm ci
npm run lint
npm run local:run
```
