### PR TITLE
test: convert to ESLint Flat config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,15 @@
 import globals from 'globals'
-import { FlatCompat } from '@eslint/eslintrc'
 import pluginJs from '@eslint/js'
 import eslintPluginJsonc from 'eslint-plugin-jsonc'
 import stylisticJs from '@stylistic/eslint-plugin-js'
 import mochaPlugin from 'eslint-plugin-mocha'
-
-const compat = new FlatCompat()
+import pluginCypress from 'eslint-plugin-cypress/flat'
 
 export default [
   pluginJs.configs.recommended,
   ...eslintPluginJsonc.configs['flat/recommended-with-json'],
   mochaPlugin.configs.flat.recommended,
+  pluginCypress.configs.recommended,
   {
     plugins: {
       '@stylistic/js': stylisticJs,
@@ -26,7 +25,5 @@ export default [
         ...globals.node
       },
     }
-  }, ...compat.config({
-    extends: ['plugin:cypress/recommended'],
-  })
+  }
 ]


### PR DESCRIPTION
## Current situation

[eslint.config.mjs](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/eslint.config.mjs) relies on using `import { FlatCompat } from '@eslint/eslintrc'` to run `eslint-plugin-cypress`.

Starting with [eslint-plugin-cypress@3.3.0](https://www.npmjs.com/package/eslint-plugin-cypress/v/3.3.0) the plugin has full support for Flat config files using:

```js
import pluginCypress from 'eslint-plugin-cypress/flat'
export default [
  pluginCypress.configs.recommended
]
```

## Change

1. Remove `@eslint/eslintrc`
2. Add `eslint-plugin-cypress/flat`

## Verification

```shell
npm ci
npm run lint
```
