### PR TITLE
test(deps): update docker image versions to node-20.14.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ executors:
     resource_class: macos.m1.medium.gen1
   browsers:
     docker:
-      - image: 'cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1'
+      - image: 'cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1'
 
 jobs:
   win-test:

--- a/.github/workflows/chrome-docker.yml
+++ b/.github/workflows/chrome-docker.yml
@@ -7,7 +7,7 @@ jobs:
   chrome:
     runs-on: ubuntu-22.04
     # https://github.com/cypress-io/cypress-docker-images
-    container: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
+    container: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ cache:
 
 # this job installs npm dependencies and Cypress
 install:
-  image: cypress/base:20.11.1
+  image: cypress/base:20.14.0
   stage: build
 
   script:
@@ -35,7 +35,7 @@ install:
 
 # all jobs that actually run tests can use the same definition
 .job_template:
-  image: cypress/base:20.11.1
+  image: cypress/base:20.14.0
   stage: test
   script:
     # print CI environment variables for reference

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://documentation.codeship.com/pro/languages-frameworks/nodejs/
 
 # use Cypress provided image with all dependencies included
-FROM cypress/base:20.11.1
+FROM cypress/base:20.14.0
 RUN node --version
 RUN npm --version
 WORKDIR /home/node/app

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
   agent {
     // this image provides everything needed to run Cypress
     docker {
-      image 'cypress/base:20.9.0'
+      image 'cypress/base:20.14.0'
     }
   }
 

--- a/basic/.circleci/config.yml
+++ b/basic/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: cypress/base:20.11.1
+      - image: cypress/base:20.14.0
     steps:
       - checkout
       # restore folders with npm dependencies and Cypress binary

--- a/basic/.gitlab-ci.yml
+++ b/basic/.gitlab-ci.yml
@@ -13,7 +13,7 @@ cache:
     - cache/Cypress
 
 test:
-  image: cypress/base:20.11.1
+  image: cypress/base:20.14.0
   stage: test
   script:
     - npm ci

--- a/basic/Jenkinsfile
+++ b/basic/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
   agent {
     // this image provides everything needed to run Cypress
     docker {
-      image 'cypress/base:20.9.0'
+      image 'cypress/base:20.14.0'
     }
   }
 

--- a/basic/codeship-pro/Dockerfile
+++ b/basic/codeship-pro/Dockerfile
@@ -2,7 +2,7 @@
 # https://documentation.codeship.com/pro/languages-frameworks/nodejs/
 
 # use Cypress provided image with all dependencies included
-FROM cypress/base:20.11.1
+FROM cypress/base:20.14.0
 RUN node --version
 RUN npm --version
 WORKDIR /home/node/app

--- a/buddy.yml
+++ b/buddy.yml
@@ -8,7 +8,7 @@
       type: "BUILD"
       working_directory: "/buddy/cypress-example-kitchensink"
       docker_image_name: "cypress/base"
-      docker_image_tag: "20.9.0"
+      docker_image_tag: "20.14.0"
       execute_commands:
         - "npm install --force"
         - "npm run cy:verify"


### PR DESCRIPTION
## Issue

Multiple example workflows use outdated Cypress Docker images.

## Change

Update to

- [cypress/base:20.14.0](https://hub.docker.com/layers/cypress/base/20.14.0/images/sha256-2314cbaca5d133d2c69f91cec9f6b6f1787b32ea2dc7c23c73bd817e0f8f4316)
- [cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1](https://hub.docker.com/layers/cypress/browsers/node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1/images/sha256-2d861960dadb4fe650d99bad6fca692cd61982ac584983a1af4de7c42ef595c1)
