### PR TITLE
chore(deps): remove @eslint/eslintrc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
       },
       "devDependencies": {
         "@bahmutov/print-env": "1.3.0",
-        "@eslint/eslintrc": "3.1.0",
         "@stylistic/eslint-plugin-js": "2.1.0",
         "cypress": "13.12.0",
         "eslint": "9.4.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@bahmutov/print-env": "1.3.0",
-    "@eslint/eslintrc": "3.1.0",
     "@stylistic/eslint-plugin-js": "2.1.0",
     "cypress": "13.12.0",
     "eslint": "9.4.0",


### PR DESCRIPTION
## Issue

- PR #845 removed the use of `@eslint/eslintrc`. It is still explicitly listed in `package.json`, which is unnecessary.

## Change

Uninstall `@eslint/eslintrc`. Note that it remains in `package-lock.json` since it is also a dependency of [eslint](https://www.npmjs.com/package/eslint).

## Verification

```shell
npm ci
npm run lint
```
