### PR TITLE
chore: normalize package.json repository protocol definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/cypress-io/cypress-example-kitchensink.git"
+    "url": "git+https://github.com/cypress-io/cypress-example-kitchensink.git"
   },
   "author": "Cypress-io",
   "license": "MIT",


### PR DESCRIPTION
## Issue

npm reports in workflow log

https://app.circleci.com/pipelines/github/cypress-io/cypress-example-kitchensink/1886/workflows/55d7c8d6-7241-4bc9-8691-d5deb7dc8b41/jobs/12980?invite=true#step-102-6007_121

> npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
> npm warn publish errors corrected:
> npm warn publish "repository.url" was normalized to "git+https://github.com/cypress-io/cypress-example-kitchensink.git"

Currently https://github.com/cypress-io/cypress-example-kitchensink/blob/b2c085df9aff01419963e9101969b87176eaa78c/package.json#L48-L51 defines the repository using the `https` protocol.

## Change

Permanently normalize the repo reference in `package.json` using `npm pkg fix` to change to `git+https` protocol:

```json
  "repository": {
    "type": "git",
    "url": "git+https://github.com/cypress-io/cypress-example-kitchensink.git"
  },
```
