### PR TITLE
ci(deps): use xcode 15.4.0 / node v20.13.1 for macos in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ orbs:
 executors:
   mac:
     macos:
-      xcode: "14.3.1"
+      xcode: "15.4.0"
     resource_class: macos.m1.medium.gen1
   browsers:
     docker:


### PR DESCRIPTION
- Partially resolves issue https://github.com/cypress-io/cypress-example-kitchensink/issues/851

## Issue

- The [.circleci/config.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.circleci/config.yml) workflow shows `EBADENGINE` warnings.

| Workflow  | Node.js    |
| --------- | ---------- |
| mac-build | `v18.16.0` |

- A minimum Node.js version of `node: '^18.18.0 || ^20.9.0 || >=21.1.0'` is needed
- [.node-version](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.node-version) specifies `20`

## Change

Change to [xcode 15.4.0](https://discuss.circleci.com/t/xcode-15-4-0-ga-released/50897) with [manifest](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v14775/manifest.txt) including:
- macOS `14.3.1`
- Node `v20.13.1` (default) / `v22.1.0`

## References

- [Testing iOS applications on macOS](https://circleci.com/docs/testing-ios/)
- [xcode](https://circleci.com/developer/machine/image/xcode) machine image