### PR TITLE
ci: convert linux tests for Node.js 20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,56 @@ jobs:
           start-command: 'npm run start'
           cypress-command: 'npx cypress run --record --group Mac build'
 
+  linux-test:
+    # checks out code and installs dependencies once
+    # runs on 3 machines, load balances tests
+    # and records on Cypress Cloud
+    parallelism: 3
+    executor:
+      name: cypress/default
+      node-version: '20.13.1'
+    steps:
+      - cypress/install:
+          post-install: 'npm run build'
+      - cypress/run-tests:
+          start-command: 'npm run start'
+          cypress-command: 'npx cypress run --record --parallel --group 3x-electron on CircleCI'
+      - run: npx cypress cache path
+      - run: npx cypress cache list
+      - run: npx cypress info
+      # let's print version info
+      - run: npx cypress version
+      - run: npx cypress version --component package
+      - run: npx cypress version --component binary
+      - run: npx cypress version --component electron
+      - run: npx cypress version --component node
+
+  linux-test-chrome:
+    # runs on 2 machines using Chrome browser
+    parallelism: 2
+    executor:
+      name: cypress/default
+      node-version: '20.13.1'
+    steps:
+      - cypress/install:
+          install-browsers: true
+      - cypress/run-tests:
+          start-command: 'npm run start'
+          cypress-command: 'npx cypress run --browser chrome --record --parallel --group 2x-chrome on CircleCI'
+
+  linux-test-firefox:
+    # runs on 2 machines using Firefox browser
+    parallelism: 2
+    executor:
+      name: cypress/default
+      node-version: '20.13.1'
+    steps:
+      - cypress/install:
+          install-browsers: true
+      - cypress/run-tests:
+          start-command: 'npm run start'
+          cypress-command: 'npx cypress run --browser firefox --record --parallel --group 2x-chrome on CircleCI'
+
   release:
     executor:
       name: cypress/default
@@ -167,42 +217,9 @@ workflows:
 
   linux-build:
     jobs:
-      # checks out code and installs dependencies once
-      # runs on 3 machines, load balances tests
-      # and records on Cypress Cloud
-      - cypress/run:
-          name: '3 machines'
-          post-install: 'npm run build'
-          start-command: 'npm run start'
-          cypress-command: 'npx cypress run --record --parallel --group 3x-electron on CircleCI'
-          parallelism: 3
-          post-steps:
-            # show Cypress cache folder and binary versions
-            # to check if we are caching previous binary versions
-            - run: npx cypress cache path
-            - run: npx cypress cache list
-            - run: npx cypress info
-            # let's print version info
-            - run: npx cypress version
-            - run: npx cypress version --component package
-            - run: npx cypress version --component binary
-            - run: npx cypress version --component electron
-            - run: npx cypress version --component node
-
-      # run on 2 machines using Chrome browser
-      - cypress/run:
-          name: '2 machines using Chrome'
-          start-command: 'npm run start'
-          install-browsers: true
-          cypress-command: 'npx cypress run --browser chrome --record --parallel --group 2x-chrome on CircleCI'
-          parallelism: 2
-
-      - cypress/run:
-          name: '2 machines using Firefox'
-          start-command: 'npm run start'
-          install-browsers: true
-          cypress-command: 'npx cypress run --browser firefox --record --parallel --group 2x-firefox on CircleCI'
-          parallelism: 2
+      - linux-test
+      - linux-test-chrome
+      - linux-test-firefox
 
       - release:
           filters:
@@ -210,6 +227,6 @@ workflows:
               only:
                 - master
           requires:
-            - 3 machines
-            - 2 machines using Chrome
-            - 2 machines using Firefox
+            - linux-test
+            - linux-test-chrome
+            - linux-test-firefox


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-example-kitchensink/issues/857

## Issue

The [.circleci/config.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.circleci/config.yml) workflow shows multiple `EBADENGINE` warnings.

The `linux-build` jobs in the `workflows` section are currently running under the Node.js default `v18.16.1` from the Cypress CircleCI Orb. They need to run under Node.js `20.x` to be compatible with currently configured dependencies.

## Change

- Move the `linux-build` jobs in the `workflows` section to the `jobs` section
- Convert the jobs from using the Cypress Circle CI Orb job [cypress/run](https://circleci.com/developer/orbs/orb/cypress-io/cypress#jobs-run) to use instead the Cypress Circle CI Orb command [cypress/run-tests](https://circleci.com/developer/orbs/orb/cypress-io/cypress#commands-run-tests).
- Add the following to the moved jobs:
    ```yaml
    executor:
      name: cypress/default
      node-version: '20.13.1'
    ```
- Rename the jobs to align to the Windows and Mac jobs
