### PR TITLE
ci: fix firefox group recording

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
           install-browsers: true
       - cypress/run-tests:
           start-command: 'npm run start'
-          cypress-command: 'npx cypress run --browser firefox --record --parallel --group 2x-chrome on CircleCI'
+          cypress-command: 'npx cypress run --browser firefox --record --parallel --group 2x-firefox on CircleCI'
 
   release:
     executor:


### PR DESCRIPTION
## Issue

- https://github.com/cypress-io/cypress-example-kitchensink/pull/859 introduced a grouping error for Firefox parallel tests in the [.circleci/config.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.circleci/config.yml) workflow. The Firefox tests are incorrectly grouped into `2x-chrome on CircleCI` which causes grouping to fail due to mismatched browsers.

This can cause either the `linux-test-chrome` or `linux-test-firefox` job to fail, depending on timing. The failure also prevents the `release` job running.

Due to the PRs coming from a fork, recording is not tested until the PR is merged since Cypress Cloud project Id and record key are secrets.

See https://app.circleci.com/pipelines/github/cypress-io/cypress-example-kitchensink/1898/workflows/a8f38ed8-12fc-4b5f-8964-6920ca320814 for failing workflow.

## Change

The Firefox tests are now correctly called with:

```yaml
cypress-command: 'npx cypress run --browser firefox --record --parallel --group 2x-firefox on CircleCI'
```
