### PR TITLE
ci: use .node-version file for GitHub Actions setup

### DIFF
--- a/.github/workflows/chrome.yml
+++ b/.github/workflows/chrome.yml
@@ -8,6 +8,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
       - name: Chrome
         uses: cypress-io/github-action@v6
         timeout-minutes: 10

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -17,10 +17,10 @@ jobs:
 
       # install a specific version of Node using
       # https://github.com/actions/setup-node
-      - name: Use Node.js 20
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .node-version
 
       # just so we learn about available environment variables GitHub provides
       - name: Print CI env variables
@@ -83,10 +83,10 @@ jobs:
 
       # install a specific version of Node using
       # https://github.com/actions/setup-node
-      - name: Use Node.js 20
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .node-version
 
       # Restore just local node_modules and the Cypress binary archives.
       - name: Cache Cypress binary
@@ -142,10 +142,10 @@ jobs:
 
       # install a specific version of Node using
       # https://github.com/actions/setup-node
-      - name: Use Node.js 20
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .node-version
 
       # Restore just local node_modules and the Cypress binary archives.
       - name: Cache Cypress binary

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -13,10 +13,10 @@ jobs:
 
     # install a specific version of Node using
     # https://github.com/actions/setup-node
-    - name: Use Node.js 20
+    - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version-file: .node-version
 
     # just so we learn about available environment variables GitHub provides
     - name: Print env variables


### PR DESCRIPTION
## Issue

The following workflow running in GitHub Actions shows a warning message: `npm warn EBADENGINE Unsupported engine`:

- [.github/workflows/chrome.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/chrome.yml)

This workflow, running in GitHub Actions [ubuntu-22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md), uses the default Node.js `18.20.4` and not Node.js `20` as specified in [.node-version](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.node-version). 

- Due to PR https://github.com/cypress-io/cypress-example-kitchensink/pull/849, a minimum Node.js `v20.8.1` is required.

## Change

Add [actions/setup-node](https://github.com/actions/setup-node) using `node-version-file` set to [.node-version](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.node-version) to:

- [.github/workflows/chrome.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/chrome.yml)

For consistency, modify the existing use of [actions/setup-node](https://github.com/actions/setup-node) to use `node-version-file` set to [.node-version](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.node-version) instead of a fixed `node-version: 20` in:

- [.github/workflows/parallel.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/parallel.yml)
- [.github/workflows/single.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/single.yml)