### PR TITLE
chore(deps): update axios to 1.7.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1612,10 +1612,11 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",


### PR DESCRIPTION
## Issue

Dependabot reports alert [Server-Side Request Forgery in axios](https://github.com/advisories/GHSA-8hc4-vh64-cxmj) for [package-lock.json](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/package-lock.json).

[axios](https://www.npmjs.com/package/axios) is a transient dependency of

https://github.com/cypress-io/cypress-example-kitchensink/blob/db9556cb3fe7e4236d2903023c18c12eb22caa94/package-lock.json#L26

## Change

Resolve the vulnerability with `npm audit fix` which updates `axios` to `1.7.4`.

## Other

- See https://github.com/jeffbski/wait-on/issues/159
