### PR TITLE
ci: migrate github action workflows to ubuntu-24.04

### DIFF
--- a/.github/workflows/chrome-docker.yml
+++ b/.github/workflows/chrome-docker.yml
@@ -5,7 +5,7 @@ on: [push, workflow_dispatch]
 jobs:
   # run Chrome inside a Docker container
   chrome:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # https://github.com/cypress-io/cypress-docker-images
     container: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
     steps:

--- a/.github/workflows/chrome.yml
+++ b/.github/workflows/chrome.yml
@@ -4,7 +4,7 @@ on: [push, workflow_dispatch]
 
 jobs:
   chrome:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -11,7 +11,7 @@ on: [push, workflow_dispatch]
 jobs:
   install:
     name: Install npm and Cypress
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -76,7 +76,7 @@ jobs:
   # anchor definitions yet, thus we cannot put same steps into a template object yet
   test1:
     name: Cypress test 1
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: install
     steps:
       - uses: actions/checkout@v4
@@ -135,7 +135,7 @@ jobs:
 
   test2:
     name: Cypress test 2
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: install
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -7,7 +7,7 @@ on: [push, workflow_dispatch]
 jobs:
   test1:
     name: Cypress test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -6,7 +6,7 @@ on: [push, workflow_dispatch]
 
 jobs:
   single-run:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,7 +19,7 @@ jobs:
 
   parallel-runs:
     name: Parallel 4x
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       # when one test fails, DO NOT cancel the other
       # containers, because this will kill Cypress processes
@@ -64,7 +64,7 @@ jobs:
       matrix:
         # run 2 copies of the current job in parallel
         # and they will load balance all specs
-        os: ['ubuntu-22.04', 'windows-latest', 'macos-latest']
+        os: ['ubuntu-24.04', 'windows-latest', 'macos-latest']
         containers: [1, 2]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Issue

The GitHub runner image [ubuntu-24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) is replacing [ubuntu-22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md) as `latest` image.

## Change

Migrate GitHub Actions workflows to [ubuntu-24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md).

Affected workflows:

- [.github/workflows/chrome-docker.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/chrome-docker.yml)
- [.github/workflows/chrome.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/chrome.yml)
- [.github/workflows/parallel.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/parallel.yml)
- [.github/workflows/single.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/single.yml)
- [.github/workflows/using-action.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/using-action.yml)