### PR TITLE
ci: remove use of @cypress/commit-message-install

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,9 +18,9 @@ install:
   # we should be using npm v6+
   - node --version
   - npm --version
-  - npm i -g @cypress/commit-message-install @bahmutov/print-env
+  - npm i -g @bahmutov/print-env
   - print-env APPVEYOR
-  - commit-message-install --else "npm ci"
+  - npm ci
 
 cache:
   # cache npm packages and Cypress binary
@@ -34,20 +34,20 @@ test_script:
   - npm run lint
   # only run if there is commit message
   # with new version
-  - run-if npm run cy:version
-  - run-if npm run cy:verify
-  - run-if npm run cy:info
-  - run-if npm run cy:cache:list
+  - npm run cy:version
+  - npm run cy:verify
+  - npm run cy:info
+  - npm run cy:cache:list
 
   # noticed really slow execution of some specs on Windows
   # leading to failures. Trying to increase the command timeout
   # maybe it will solve it
   - setx CYPRESS_defaultCommandTimeout 20000
-  - run-if npm run test:ci:record:chrome
-  - run-if npm run test:ci:record
+  - npm run test:ci:record:chrome
+  - npm run test:ci:record
   # removed Firefox test due to flakiness in this environment
-  # - run-if npm run test:ci:record:firefox
-  - run-if npm run test:ci:record:edge
+  # - npm run test:ci:record:firefox
+  - npm run test:ci:record:edge
 
 # Don't actually build.
 build: off


### PR DESCRIPTION
## Issue

The [AppVeyor](https://ci.appveyor.com/project/cypress-io/cypress-example-kitchensink?fullLog=true) workflow, which runs CI under Windows, logs multiple deprecation messages, including:

```text
npm i -g @cypress/commit-message-install @bahmutov/print-env
npm warn deprecated debug@4.1.1: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
npm warn deprecated @octokit/app@2.2.2: '@octokit/app' will be repurposed in future. Use '@octokit/auth-app' instead
```

```text
commit-message-install --else "npm ci"
(node:3700) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

```text
run-if npm run cy:version
(node:1692) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

## Analysis

Each of the deprecations comes from [@cypress/commit-message-install@3.1.3](https://github.com/cypress-io/commit-message-install/releases/tag/v3.1.3) (current `latest`), released in Apr 2020 used in the workflow [appveyor.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/appveyor.yml):

```text
$ npm ls debug
└─┬ @cypress/commit-message-install@3.1.3
  ├─┬ @cypress/set-commit-status@1.3.4
  │ └── debug@4.1.1 deduped
  └── debug@4.1.1
```

```text
$ npm ls @octokit/app
└─┬ @cypress/commit-message-install@3.1.3
  └─┬ @cypress/set-commit-status@1.3.4
    └── @octokit/app@2.2.2
```

```text
$ npx commit-message-install
(node:4685) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

```text
$ NODE_OPTIONS='--trace-deprecation' npx commit-message-install
(node:4706) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
    at node:punycode:3:9
    at BuiltinModule.compileForInternalLoader (node:internal/bootstrap/realm:399:7)
    at BuiltinModule.compileForPublicLoader (node:internal/bootstrap/realm:338:10)
    at loadBuiltinModule (node:internal/modules/helpers:114:7)
    at Function._load (node:internal/modules/cjs/loader:1100:17)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:218:24)
    at Module.require (node:internal/modules/cjs/loader:1340:12)
    at require (node:internal/modules/helpers:141:16)
    at Object.<anonymous> (/home/mike/github/commit-message-install-test/node_modules/whatwg-url/lib/url-state-machine.js:2:18)
```

```text
$ npm ls whatwg-url
└─┬ @cypress/commit-message-install@3.1.3
  └─┬ @cypress/set-commit-status@1.3.4
    └─┬ @octokit/app@2.2.2
      └─┬ @octokit/request@2.4.2
        └─┬ node-fetch@2.7.0
          └── whatwg-url@5.0.0
```

[@cypress/commit-message-install](https://github.com/cypress-io/commit-message-install) is only used in the [appveyor.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/appveyor.yml) workflow. The functionality of [@cypress/commit-message-install](https://github.com/cypress-io/commit-message-install) to install a package using instructions hidden in a commit message is unused.

## Change

Remove the use of [@cypress/commit-message-install](https://github.com/cypress-io/commit-message-install) in the [appveyor.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/appveyor.yml) workflow. This includes removal of commands using:

`commit-message-install`
`run-if`

## Verification

Confirm that the [AppVeyor](https://ci.appveyor.com/project/cypress-io/cypress-example-kitchensink?fullLog=true) workflow does not contain the deprecation messages mentioned above.
