### PR TITLE
docs: AWS codebuild: Avoid branch names like `main~3`.

### DIFF
--- a/basic/buildspec.yml
+++ b/basic/buildspec.yml
@@ -7,7 +7,7 @@ phases:
     commands:
       # Set COMMIT_INFO variables to send Git specifics to Cypress Cloud when recording
       # https://docs.cypress.io/guides/continuous-integration/introduction#Git-information
-      - export COMMIT_INFO_BRANCH="$(git rev-parse HEAD | xargs git name-rev | cut -d' ' -f2 | sed 's/remotes\/origin\///g')"
+      - export COMMIT_INFO_BRANCH="$(git rev-parse HEAD | xargs git name-rev | cut -d' ' -f2 | sed 's/remotes\/origin\///g' | sed 's/~.\+$//g')"
       - export COMMIT_INFO_MESSAGE="$(git log -1 --pretty=%B)"
       - export COMMIT_INFO_EMAIL="$(git log -1 --pretty=%ae)"
       - export COMMIT_INFO_AUTHOR="$(git log -1 --pretty=%an)"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -28,7 +28,7 @@ phases:
     commands:
       # Set COMMIT_INFO variables to send Git specifics to Cypress Cloud when recording
       # https://docs.cypress.io/guides/continuous-integration/introduction#Git-information
-      - export COMMIT_INFO_BRANCH="$(git rev-parse HEAD | xargs git name-rev | cut -d' ' -f2 | sed 's/remotes\/origin\///g')"
+      - export COMMIT_INFO_BRANCH="$(git rev-parse HEAD | xargs git name-rev | cut -d' ' -f2 | sed 's/remotes\/origin\///g' | sed 's/~.\+$//g')"
       - export COMMIT_INFO_MESSAGE="$(git log -1 --pretty=%B)"
       - export COMMIT_INFO_EMAIL="$(git log -1 --pretty=%ae)"
       - export COMMIT_INFO_AUTHOR="$(git log -1 --pretty=%an)"


### PR DESCRIPTION
When the main branch has advanced compared to the currently checked out commit,`git name-rev` will print e.g. `main~3`.

To keep Cypress branch names clean, we want `COMMIT_INFO_BRANCH` to be just `main`, though.

Therefore, I suggest cutting off the suffix.

---

If this gets merged, I believe the docs have to be afterwards updated in multiple places, too, e.g. here: https://github.com/cypress-io/cypress-documentation/blob/main/docs/app/continuous-integration/aws-codebuild.mdx

I could do that, too, if desired, but of course don't have an overview of _all_ the correct places.