### PR TITLE
Refactor/simplify git name rev

### DIFF
--- a/basic/buildspec.yml
+++ b/basic/buildspec.yml
@@ -7,7 +7,7 @@ phases:
     commands:
       # Set COMMIT_INFO variables to send Git specifics to Cypress Cloud when recording
       # https://docs.cypress.io/guides/continuous-integration/introduction#Git-information
-      - export COMMIT_INFO_BRANCH="$(git rev-parse HEAD | xargs git name-rev | cut -d' ' -f2 | sed 's/remotes\/origin\///g')"
+      - export COMMIT_INFO_BRANCH="$(git rev-parse HEAD | xargs git name-rev | cut -d' ' -f2 | sed 's/remotes\/origin\///g') | sed 's/~.\+$//g'"
       - export COMMIT_INFO_MESSAGE="$(git log -1 --pretty=%B)"
       - export COMMIT_INFO_EMAIL="$(git log -1 --pretty=%ae)"
       - export COMMIT_INFO_AUTHOR="$(git log -1 --pretty=%an)"

--- a/basic/buildspec.yml
+++ b/basic/buildspec.yml
@@ -7,7 +7,7 @@ phases:
     commands:
       # Set COMMIT_INFO variables to send Git specifics to Cypress Cloud when recording
       # https://docs.cypress.io/guides/continuous-integration/introduction#Git-information
-      - export COMMIT_INFO_BRANCH="$(git rev-parse HEAD | xargs git name-rev | cut -d' ' -f2 | sed 's/remotes\/origin\///g') | sed 's/~.\+$//g'"
+      - export COMMIT_INFO_BRANCH="$(git rev-parse HEAD | git name-rev --stdin --name-only | sed 's/remotes\/origin\///g') | sed 's/~.\+$//g'"
       - export COMMIT_INFO_MESSAGE="$(git log -1 --pretty=%B)"
       - export COMMIT_INFO_EMAIL="$(git log -1 --pretty=%ae)"
       - export COMMIT_INFO_AUTHOR="$(git log -1 --pretty=%an)"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -28,7 +28,7 @@ phases:
     commands:
       # Set COMMIT_INFO variables to send Git specifics to Cypress Cloud when recording
       # https://docs.cypress.io/guides/continuous-integration/introduction#Git-information
-      - export COMMIT_INFO_BRANCH="$(git rev-parse HEAD | xargs git name-rev | cut -d' ' -f2 | sed 's/remotes\/origin\///g')"
+      - export COMMIT_INFO_BRANCH="$(git rev-parse HEAD | xargs git name-rev | cut -d' ' -f2 | sed 's/remotes\/origin\///g') | sed 's/~.\+$//g'"
       - export COMMIT_INFO_MESSAGE="$(git log -1 --pretty=%B)"
       - export COMMIT_INFO_EMAIL="$(git log -1 --pretty=%ae)"
       - export COMMIT_INFO_AUTHOR="$(git log -1 --pretty=%an)"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -28,7 +28,7 @@ phases:
     commands:
       # Set COMMIT_INFO variables to send Git specifics to Cypress Cloud when recording
       # https://docs.cypress.io/guides/continuous-integration/introduction#Git-information
-      - export COMMIT_INFO_BRANCH="$(git rev-parse HEAD | xargs git name-rev | cut -d' ' -f2 | sed 's/remotes\/origin\///g') | sed 's/~.\+$//g'"
+      - export COMMIT_INFO_BRANCH="$(git rev-parse HEAD | git name-rev --stdin --name-only | sed 's/remotes\/origin\///g') | sed 's/~.\+$//g'"
       - export COMMIT_INFO_MESSAGE="$(git log -1 --pretty=%B)"
       - export COMMIT_INFO_EMAIL="$(git log -1 --pretty=%ae)"
       - export COMMIT_INFO_AUTHOR="$(git log -1 --pretty=%an)"


### PR DESCRIPTION
`git name-rev` has some scripting-friendly options which avoid the need to use `cut`.

---

This builds on top of https://github.com/cypress-io/cypress-example-kitchensink/pull/919, to avoid merge conflicts.

If https://github.com/cypress-io/cypress-example-kitchensink/pull/919 is not merged, I can re-open this as a standalone PR, if desired.

