### PR TITLE
chore: remove CommonJS comment from cypress/support/e2e.js

### DIFF
--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -15,6 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')


### PR DESCRIPTION
## Issue

[cypress/support/e2e.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/support/e2e.js) no longer corresponds to the default scaffolded file contents.

Cypress dynamically builds support files when scaffolding based on the texts in https://github.com/cypress-io/cypress/blob/develop/packages/scaffold-config/src/supportFile.ts. For E2E tests the text is:

```js
    // ***********************************************************
    // This example support/e2e.${language} is processed and
    // loaded automatically before your test files.
    //
    // This is a great place to put global configuration and
    // behavior that modifies Cypress.
    //
    // You can change the location of this file or turn off
    // automatically serving support files with the
    // 'supportFile' configuration option.
    //
    // You can read more here:
    // https://on.cypress.io/configuration
    // ***********************************************************

    // Import commands.js using ES2015 syntax:
    import './commands'
```

- PR https://github.com/cypress-io/cypress/pull/30738 removed the comment text as listed in the release notes for [cypress@13.17.0](https://docs.cypress.io/app/references/changelog#13-17-0)

```js
    // Alternatively you can use CommonJS syntax:
    // require('./commands')
```

## Change

Remove the outdated comment text from [cypress/support/e2e.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/support/e2e.js) to align with Cypress `13.17.0` and later.

```js
    // Alternatively you can use CommonJS syntax:
    // require('./commands')
```
