### PR TITLE
chore: allow successful default linting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,9 @@ export default [
   mochaPlugin.configs.flat.recommended,
   pluginCypress.configs.recommended,
   {
+    ignores: ['app/assets/js/vendor/']
+  },
+  {
     plugins: {
       '@stylistic/js': stylisticJs,
     },

--- a/scripts/set-port.js
+++ b/scripts/set-port.js
@@ -1,5 +1,5 @@
 /* eslint-env node */
-/* eslint-disable no-console */
+ 
 const { readFileSync, writeFileSync } = require('fs')
 
 // On some CIs like Heroku CI the host assigns random PORT and

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -7,7 +7,7 @@ if (process.env.CI) cmd += ` --no-clipboard`
 
 if (process.argv.length > 2) cmd += ` ${process.argv.slice(2).join(' ')}`
 
-// eslint-disable-next-line no-console
+ 
 console.log(`Running "${cmd}"...`)
 
 execSync(cmd, { stdio: 'inherit' })


### PR DESCRIPTION
## Issue

Executing

```shell
npx eslint
```

reports failures from

- `.js` files in `scripts`
- third-party `.js` files in `app/assets/js/vendor/*`

## Change

1. Remove unnecessary `// eslint-disable-next-line no-console` in `scripts/*.js`
2. Add `ignores: ['app/assets/js/vendor/']` as a [global ignore configuration object](https://eslint.org/docs/latest/use/configure/configuration-files#globally-ignoring-files-with-ignores)

## Verify

Execute

```shell
npx eslint
npm run lint
```

and confirm that no errors and no git changes are reported.