### PR TITLE
test: add setup-node to using-action workflow

### DIFF
--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -10,6 +10,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
       - name: Cypress run
         uses: cypress-io/github-action@v6
         timeout-minutes: 10
@@ -38,7 +42,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
@@ -70,7 +77,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests


### PR DESCRIPTION
## Issue

The workflow [.github/workflows/using-action.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/using-action.yml) runs using the GitHub Actions runner default Node.js version `18.20.7` in [windows-latest / windows-2022](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md). This is not compatible with the configured [semantic-release@24.1.3](https://github.com/semantic-release/semantic-release/releases/tag/v24.1.3), which requires Node.js >= `20.8.1`.

The job `parallel-runs-across-platforms` displays a warning in the step `run tests`:

> npm warn EBADENGINE Unsupported engine

## Change

Add the following to each job in the workflow [.github/workflows/using-action.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/using-action.yml) to ensure a consistent Node.js version is being used:

```yml
      - name: Set up Node.js
        uses: actions/setup-node@v4
        with:
          node-version-file: .node-version
```

## Verification

Check all jobs of workflow [.github/workflows/using-action.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/using-action.yml) and ensure there are no `EBADENGINE` warnings.