### PR TITLE
ci: use node.js 22 in circleci windows jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ version: 2.1
 orbs:
   # use Cypress orb from CircleCI registry
   cypress: cypress-io/cypress@3.4.3
-  win: circleci/windows@5.0.0
+  win: circleci/windows@5.1.0
 
 executors:
   mac:
@@ -28,7 +28,12 @@ jobs:
       shell: bash.exe
     steps:
       - checkout
-
+      - run:
+          name: Install Node.js
+          command: |
+            nvm --version
+            nvm install 22
+            nvm use 22
       - restore_cache:
           key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
 
@@ -63,7 +68,12 @@ jobs:
       shell: bash.exe
     steps:
       - checkout
-
+      - run:
+          name: Install Node.js
+          command: |
+            nvm --version
+            nvm install 22
+            nvm use 22
       - restore_cache:
           key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
 
@@ -101,7 +111,12 @@ jobs:
       shell: bash.exe
     steps:
       - checkout
-
+      - run:
+          name: Install Node.js
+          command: |
+            nvm --version
+            nvm install 22
+            nvm use 22
       - restore_cache:
           key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
 


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-example-kitchensink/issues/938

## Situation

Currently the CI pipeline [.circleci/config.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.circleci/config.yml) workflow `win-build` runs using the default Node.js version `v21.7.3` of the CircleCI [windows-orb@5.0.0](https://github.com/CircleCI-Public/windows-orb/releases/tag/v5.0.0).

Node.js version `v21.7.3` is however no longer supported by [Node.js](https://github.com/nodejs/release#release-schedule), nor by [Cypress](https://docs.cypress.io/app/get-started/install-cypress#Nodejs). It reached its [end-of-life milestone](https://github.com/nodejs/release#release-schedule) on June 1, 2024 already.

## Change

1. Update from [windows-orb@5.0.0](https://github.com/CircleCI-Public/windows-orb/releases/tag/v5.0.0) to [windows-orb@5.1.0](https://github.com/CircleCI-Public/windows-orb/releases/tag/v5.1.0). This is a minor housekeeping update only, that should have no impact.
2. In each of the jobs in the CI pipeline [.circleci/config.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.circleci/config.yml) workflow `win-build` use nvm to install Node.js `22` corresponding to the Node.js version stored in [.node-version](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.node-version).

## Verify

Review the logs of https://app.circleci.com/pipelines/github/cypress-io/cypress-example-kitchensink workflow `win-build` and confirm that in each job

- `win-test`
- `win-test-chrome`
- `win-test-firefox`


1. the "npm ci" step shows no `npm WARN EBADENGINE Unsupported engine` warning
2. the "Run Cypress tests" logs Cypress running under Node.js `v22.14.0`
