### PR TITLE
ci: use node.js 22 in circleci mac job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ orbs:
 executors:
   mac:
     macos:
-      xcode: "15.4.0"
+      xcode: "16.2.0"
     resource_class: macos.m1.medium.gen1
   browsers:
     docker:
@@ -134,6 +134,11 @@ jobs:
   mac-test:
     executor: mac
     steps:
+      - run:
+          name: Install Node.js
+          command: |
+            nvm install 22
+            nvm use 22
       - cypress/install:
           post-install: "npm run build"
       # show Cypress cache folder and binary versions


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-example-kitchensink/issues/940

## Situation

The CI pipeline [.circleci/config.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.circleci/config.yml) workflow `mac-build` runs in Node.js `v20.13.1`.

It should run in the Node.js version specified in [.node-version](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.node-version), which is currently `22`.

## Change

1. Update to executor [xcode@16.2.0](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v15180/manifest.txt)

2. Use [nvm](https://github.com/nvm-sh/nvm) to install Node.js `22` in the CI pipeline [.circleci/config.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.circleci/config.yml) workflow `mac-build` job `mac-test`

    This corresponds to the Node.js version stored in [.node-version](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.node-version).
