### PR TITLE
chore(deps): update start-server-and-test to 2.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "globby": "11.1.0",
         "husky": "9.0.6",
         "semantic-release": "24.2.3",
-        "start-server-and-test": "2.0.9",
+        "start-server-and-test": "2.0.11",
         "yaml-lint": "1.7.0"
       },
       "engines": {
@@ -1510,9 +1510,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8944,9 +8944,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9790,9 +9790,9 @@
       }
     },
     "node_modules/start-server-and-test": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-2.0.9.tgz",
-      "integrity": "sha512-DDceIvc4wdpr+z3Aqkot2QMho8TcUBh5qH0wEHDpEexBTzlheOcmh53d3dExABY4J5C7qS2UbSXqRWLtxpbWIQ==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-2.0.11.tgz",
+      "integrity": "sha512-TN39gLzPhHAflxyOkE/oMfQGj+pj3JgF6qVicFH/JrXt7xXktidKXwqfRga+ve7lVA8+RgPZVc25VrEPRScaDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9803,7 +9803,7 @@
         "execa": "5.1.1",
         "lazy-ass": "1.6.0",
         "ps-tree": "1.2.0",
-        "wait-on": "8.0.1"
+        "wait-on": "8.0.3"
       },
       "bin": {
         "server-test": "src/bin/start.js",
@@ -10483,17 +10483,17 @@
       "license": "MIT"
     },
     "node_modules/wait-on": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.1.tgz",
-      "integrity": "sha512-1wWQOyR2LVVtaqrcIL2+OM+x7bkpmzVROa0Nf6FryXkS+er5Sa1kzFGjzZRqLnHa3n1rACFLeTwUqE1ETL9Mig==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.3.tgz",
+      "integrity": "sha512-nQFqAFzZDeRxsu7S3C7LbuxslHhk+gnJZHyethuGKAn2IVleIbTB9I3vJSQiSR+DifUqmdzfPMoMPJfLqMF2vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.7.7",
+        "axios": "^1.8.2",
         "joi": "^17.13.3",
         "lodash": "^4.17.21",
         "minimist": "^1.2.8",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.2"
       },
       "bin": {
         "wait-on": "bin/wait-on"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "globby": "11.1.0",
     "husky": "9.0.6",
     "semantic-release": "24.2.3",
-    "start-server-and-test": "2.0.9",
+    "start-server-and-test": "2.0.11",
     "yaml-lint": "1.7.0"
   },
   "engines": {


### PR DESCRIPTION
## Issue

`npm audit` reports a high severity vulnerability [CVE-2025-27152](https://github.com/advisories/GHSA-jr5f-v2jv-69x6) due to
`axios  <1.8.2` as transient dependency:

```text
└─┬ start-server-and-test@2.0.9
  └─┬ wait-on@8.0.1
    └── axios@1.7.9
```

## Change

Update from [start-server-and-test@2.0.9](https://github.com/bahmutov/start-server-and-test/releases/tag/v2.0.9) to [start-server-and-test@2.0.11](https://github.com/bahmutov/start-server-and-test/releases/tag/v2.0.11)

```text
└─┬ start-server-and-test@2.0.11
  └─┬ wait-on@8.0.3
    └── axios@1.8.4
```
