### PR TITLE
ci: remove unused browsers executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,7 @@ executors:
     macos:
       xcode: "15.4.0"
     resource_class: macos.m1.medium.gen1
-  browsers:
-    docker:
-      - image: 'cypress/browsers:node-22.13.0-chrome-132.0.6834.83-1-ff-134.0.1-edge-131.0.2903.147-1'
+
 jobs:
   win-test:
     working_directory: ~/app


### PR DESCRIPTION
## Situation

The `browsers` executor in the pipeline [.circleci/config.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.circleci/config.ym) is unused code:

https://github.com/cypress-io/cypress-example-kitchensink/blob/8d10f646e2aa35731f10bbe4e3e265bdf7b5001e/.circleci/config.yml#L19-L21

- This has been the case since PR #591 in March 2023. Browsers are provided through the `cypress-io/cypress@3` Orb.

## Change

Remove the dead code `browsers` executor from the pipeline [.circleci/config.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.circleci/config.ym).
