### PR TITLE
chore(deps): update ci examples to node 22.15.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
     parallelism: 3
     executor:
       name: cypress/default
-      node-version: '22.11.0'
+      node-version: '22.15.0'
     steps:
       - cypress/install:
           post-install: 'npm run build'
@@ -192,7 +192,7 @@ jobs:
     parallelism: 2
     executor:
       name: cypress/default
-      node-version: '22.11.0'
+      node-version: '22.15.0'
     steps:
       - cypress/install:
           install-browsers: true
@@ -205,7 +205,7 @@ jobs:
     parallelism: 2
     executor:
       name: cypress/default
-      node-version: '22.11.0'
+      node-version: '22.15.0'
     steps:
       - cypress/install:
           install-browsers: true
@@ -216,7 +216,7 @@ jobs:
   release:
     executor:
       name: cypress/default
-      node-version: '22.11.0'
+      node-version: '22.15.0'
     steps:
       - checkout
       - run: npm ci

--- a/.github/workflows/chrome-docker.yml
+++ b/.github/workflows/chrome-docker.yml
@@ -7,7 +7,7 @@ jobs:
   chrome:
     runs-on: ubuntu-24.04
     # https://github.com/cypress-io/cypress-docker-images
-    container: cypress/browsers:node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1
+    container: cypress/browsers:22.15.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ cache:
 
 # this job installs npm dependencies and Cypress
 install:
-  image: cypress/base:22.14.0
+  image: cypress/base:22.15.0
   stage: build
 
   script:
@@ -35,7 +35,7 @@ install:
 
 # all jobs that actually run tests can use the same definition
 .job_template:
-  image: cypress/base:22.14.0
+  image: cypress/base:22.15.0
   stage: test
   script:
     # print CI environment variables for reference

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -68,7 +68,7 @@ blocks:
       # common commands that should be done before each E2E test command
       prologue:
         commands:
-          - nvm install 20
+          - nvm install 22
           - npm install -g npm
           - checkout
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   - PUPPETEER_SKIP_DOWNLOAD=1
 
 node_js:
-  - 20
+  - 22
 
 cache:
   # cache both npm modules and Cypress binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://documentation.codeship.com/pro/languages-frameworks/nodejs/
 
 # use Cypress provided image with all dependencies included
-FROM cypress/base:22.14.0
+FROM cypress/base:22.15.0
 RUN node --version
 RUN npm --version
 WORKDIR /home/node/app

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
   agent {
     // this image provides everything needed to run Cypress
     docker {
-      image 'cypress/base:22.11.0'
+      image 'cypress/base:22.15.0'
     }
   }
 

--- a/basic/.circleci/config.yml
+++ b/basic/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: cypress/base:22.14.0
+      - image: cypress/base:22.15.0
     steps:
       - checkout
       # restore folders with npm dependencies and Cypress binary

--- a/basic/.gitlab-ci.yml
+++ b/basic/.gitlab-ci.yml
@@ -13,7 +13,7 @@ cache:
     - cache/Cypress
 
 test:
-  image: cypress/base:22.14.0
+  image: cypress/base:22.15.0
   stage: test
   script:
     - npm ci

--- a/basic/.semaphore.yml
+++ b/basic/.semaphore.yml
@@ -20,7 +20,7 @@ blocks:
       jobs:
         - name: npm ci and cache
           commands:
-            - nvm install 20
+            - nvm install 22
             - npm install -g npm
             - checkout
 

--- a/basic/.travis.yml
+++ b/basic/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - 20
+  - 22
 
 cache:
   # cache both npm modules and Cypress binary

--- a/basic/Jenkinsfile
+++ b/basic/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
   agent {
     // this image provides everything needed to run Cypress
     docker {
-      image 'cypress/base:22.11.0'
+      image 'cypress/base:22.15.0'
     }
   }
 

--- a/basic/buildspec.yml
+++ b/basic/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 20
+      nodejs: 22
     commands:
       # Set COMMIT_INFO variables to send Git specifics to Cypress Cloud when recording
       # https://docs.cypress.io/guides/continuous-integration/introduction#Git-information

--- a/basic/codeship-pro/Dockerfile
+++ b/basic/codeship-pro/Dockerfile
@@ -2,7 +2,7 @@
 # https://documentation.codeship.com/pro/languages-frameworks/nodejs/
 
 # use Cypress provided image with all dependencies included
-FROM cypress/base:22.14.0
+FROM cypress/base:22.15.0
 RUN node --version
 RUN npm --version
 WORKDIR /home/node/app

--- a/buddy.yml
+++ b/buddy.yml
@@ -8,7 +8,7 @@
       type: "BUILD"
       working_directory: "/buddy/cypress-example-kitchensink"
       docker_image_name: "cypress/base"
-      docker_image_tag: "22.11.0"
+      docker_image_tag: "22.15.0"
       execute_commands:
         - "npm install --force"
         - "npm run cy:verify"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -24,7 +24,7 @@ build-matrix:
 phases:
   install:
     runtime-versions:
-      nodejs: latest
+      nodejs: 22
     commands:
       # Set COMMIT_INFO variables to send Git specifics to Cypress Cloud when recording
       # https://docs.cypress.io/guides/continuous-integration/introduction#Git-information


### PR DESCRIPTION
## Issue

Example workflows are using inconsistent versions of Node.js:

- `20`
- `22.11.0`
- `22.14.0`
- `latest`

This was partially caused by Renovate PR https://github.com/cypress-io/cypress-example-kitchensink/pull/951 updating some Cypress Docker usage from `cypress/base:22.11.0` to `cypress/base:22.14.0`, leaving other instances still using `cypress/base:22.11.0` or directly using Node.js `22.11.0`.

## Change

Update Node.js usage to latest [Active LTS version](https://nodejs.org/en/about/previous-releases):

- Cypress Docker images to  `cypress/base:22.15.0`
- other Node.js versions to `22.15.0` or generic `22`