### PR TITLE
test: add stylistic rules (comma-dangle, quotes and semi)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,7 @@ export default [
   mochaPlugin.configs.recommended,
   pluginCypress.configs.recommended,
   {
-    ignores: ['app/assets/js/vendor/']
+    ignores: ['app/assets/js/vendor/'],
   },
   {
     plugins: {
@@ -19,14 +19,17 @@ export default [
     },
     rules: {
       '@stylistic/indent': ['error', 2, { 'SwitchCase': 1, 'MemberExpression': 'off' }],
+      '@stylistic/comma-dangle': ['error', 'always-multiline'],
+      '@stylistic/quotes': ['error', 'single'],
+      '@stylistic/semi': ['error', 'never'],
       'mocha/no-exclusive-tests': 'error',
       'mocha/no-pending-tests': 'error',
-      'mocha/no-mocha-arrows': 'off'
+      'mocha/no-mocha-arrows': 'off',
     },
     languageOptions: {
       globals: {
-        ...globals.node
+        ...globals.node,
       },
-    }
-  }
+    },
+  },
 ]

--- a/scripts/set-port.js
+++ b/scripts/set-port.js
@@ -1,5 +1,5 @@
 /* eslint-env node */
- 
+
 const { readFileSync, writeFileSync } = require('fs')
 
 // On some CIs like Heroku CI the host assigns random PORT and

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -3,11 +3,10 @@ const { execSync } = require('child_process')
 const port = process.env.PORT || 8080
 let cmd = `serve --listen ${port} --no-request-logging`
 
-if (process.env.CI) cmd += ` --no-clipboard`
+if (process.env.CI) cmd += ' --no-clipboard'
 
 if (process.argv.length > 2) cmd += ` ${process.argv.slice(2).join(' ')}`
 
- 
 console.log(`Running "${cmd}"...`)
 
 execSync(cmd, { stdio: 'inherit' })


### PR DESCRIPTION
## Situation

The repo already uses [@stylistic/eslint-plugin](https://eslint.style/) to lint styling in the repo according to the configuration in [eslint.config.mjs](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/eslint.config.mjs) which specifies:

```js
    plugins: {
      '@stylistic': stylistic,
    },
    rules: {
      '@stylistic/indent': ['error', 2, { 'SwitchCase': 1, 'MemberExpression': 'off' }],
    },
```

and therefore only uses one `@stylistic/eslint-plugin` rule.

The use of JavaScript `comma-dangle`, `quotes` and `semi` is left undefined.

## Comparison

Other repos:

- https://github.com/cypress-io/cypress-docker-images in [eslint.config.mjs](https://github.com/cypress-io/cypress-docker-images/blob/master/eslint.config.mjs)
- https://github.com/cypress-io/github-action in [eslint.config.mjs](https://github.com/cypress-io/github-action/blob/master/eslint.config.mjs)

specify

```js
    rules: {
      '@stylistic/indent': ['error', 2],
      '@stylistic/comma-dangle': ['error', 'always-multiline'],
      '@stylistic/quotes': ['error', 'single'],
      '@stylistic/semi': ['error', 'never'],
    },
```

## Change

Bring this repo in line with [cypress-docker-images](https://github.com/cypress-io/cypress-docker-images) and [github-action](https://github.com/cypress-io/github-action) concerning JavaScript `comma-dangle`, `quotes` and `semi` by adding the following rules to [eslint.config.mjs](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/eslint.config.mjs)

```js
    rules: {
      '@stylistic/comma-dangle': ['error', 'always-multiline'],
      '@stylistic/quotes': ['error', 'single'],
      '@stylistic/semi': ['error', 'never'],
    },
```

## Test

Execute the following and confirm that no errors are reported and no changes are suggested:

```shell
npm ci
npx eslint
```
