### PR TITLE
fix: app html stray end tag syntax errors

### DIFF
--- a/app/commands/waiting.html
+++ b/app/commands/waiting.html
@@ -108,13 +108,13 @@ cy.wait('@getComment').its('response.statusCode').should('be.oneOf', [200, 304])
           </div>
         </div>
         <div class="col-xs-12">
-          <p>More information:
+          <div>More information:
             <ul>
               <li><a href="https://www.cypress.io/blog/2019/12/23/asserting-network-calls-from-cypress-tests/">Asserting Network Calls from Cypress Tests</a> blog post</li>
               <li><a href="https://github.com/cypress-io/cypress-example-recipes#unit-testing">Unit testing application code</a> recipe</li>
               <li>Avoid hard-coded waits using built-in <a href="https://on.cypress.io/retry-ability">retry-ability</a></li>
             </ul>
-          </p>
+          </div>
         </div>
 
         <div class="col-xs-12"><hr></div>

--- a/app/commands/window.html
+++ b/app/commands/window.html
@@ -95,7 +95,6 @@
 
         <div class="col-xs-12"><hr></div>
 
-        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Situation

Two of the app source documents contain syntax errors with stray end tags:

| Source                                                                                                                       | Destination                                 |
| ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [app/commands/waiting.html](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/app/commands/waiting.html) | https://example.cypress.io/commands/waiting |
| [app/commands/window.html](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/app/commands/window.html)   | https://example.cypress.io/commands/window  |

## Logs

    ```text
    app/commands/waiting.html
    [error] app/commands/waiting.html: SyntaxError: Unexpected closing tag "p". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags (117:11)
    [error]   115 |               <li>Avoid hard-coded waits using built-in <a href="https://on.cypress.io/retry-ability">retry-ability</a></li>
    [error]   116 |             </ul>
    [error] > 117 |           </p>
    [error]       |           ^^^^
    [error]   118 |         </div>
    [error]   119 |
    [error]   120 |         <div class="col-xs-12"><hr></div>

    app/commands/window.html
    [error] app/commands/window.html: SyntaxError: Unexpected closing tag "div". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags (101:3)
    [error]    99 |       </div>
    [error]   100 |     </div>
    [error] > 101 |   </div>
    [error]       |   ^^^^^^
    [error]   102 |
    [error]   103 |   <script src="/assets/js/vendor/jquery-1.12.0.min.js"></script>
    [error]   104 |   <script src="/assets/js/vendor/bootstrap.min.js"></script>
    ```

## Change

| Source                                                                                                                        | Resolution                                                                                                                                                           |
| ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [app/commands/waiting.html](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/app/commands/waiting.html) | change the`<p>` to `<div>`. It is not allowed for a `<p>` element to contain `<ul>`. See https://html.spec.whatwg.org/multipage//grouping-content.html#the-p-element |
| [app/commands/window.html](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/app/commands/window.html)   | remove unmatched `</div>` tag                                                                                                                                        |

## Verification

```shell
npm install prettier -g
npx prettier app/commands --check
```

Confirm that no syntax errors are reported.

```shell
npm run test:ci
```

Confirm that Cypress tests all pass.
