### PR TITLE
feat: apply stylistic recommended rules to examples

### DIFF
--- a/app/commands/actions.html
+++ b/app/commands/actions.html
@@ -82,9 +82,9 @@ cy.get('.action-email').type('{leftarrow}{rightarrow}{uparrow}{downarrow}')
 cy.get('.action-email').type('{del}{selectall}{backspace}')
 
 // .type() with key modifiers
-cy.get('.action-email').type('{alt}{option}') //these are equivalent
-cy.get('.action-email').type('{ctrl}{control}') //these are equivalent
-cy.get('.action-email').type('{meta}{command}{cmd}') //these are equivalent
+cy.get('.action-email').type('{alt}{option}') // these are equivalent
+cy.get('.action-email').type('{ctrl}{control}') // these are equivalent
+cy.get('.action-email').type('{meta}{command}{cmd}') // these are equivalent
 cy.get('.action-email').type('{shift}')
 
 // Delay each keypress by 0.1 sec
@@ -182,7 +182,7 @@ cy.get('.action-clear').should('have.value', '')</code></pre>
           <p>To submit a form, use the <a href="https://on.cypress.io/submit"><code>cy.submit()</code></a> command.</p>
           <pre><code class="javascript">cy.get('.action-form')
   .find('[type="text"]').type('HALFOFF')
-      
+
 cy.get('.action-form').submit()
 cy.get('.action-form').next().should('contain', 'Your form has been submitted!')</code></pre>
         </div>

--- a/app/commands/misc.html
+++ b/app/commands/misc.html
@@ -123,7 +123,8 @@ cy.log(`Platform ${Cypress.platform} architecture ${Cypress.arch}`)
 if (Cypress.platform === 'win32') {
   cy.exec('print cypress.config.js')
     .its('stderr').should('be.empty')
-} else {
+}
+else {
   cy.exec('cat cypress.config.js')
     .its('stderr').should('be.empty')
 

--- a/app/commands/storage.html
+++ b/app/commands/storage.html
@@ -141,9 +141,9 @@ cy.getAllLocalStorage().should((storageMap) => {
   expect(storageMap).to.deep.equal({
     // other origins will also be present if localStorage is set on them
     'http://localhost:8080': {
-      'prop1': 'red',
-      'prop2': 'blue',
-      'prop3': 'magenta',
+      prop1: 'red',
+      prop2: 'blue',
+      prop3: 'magenta',
     },
   })
 })</code></pre>
@@ -191,9 +191,9 @@ cy.getAllSessionStorage().should((storageMap) => {
   expect(storageMap).to.deep.equal({
     // other origins will also be present if sessionStorage is set on them
     'http://localhost:8080': {
-      'prop4': 'cyan',
-      'prop5': 'yellow',
-      'prop6': 'black',
+      prop4: 'cyan',
+      prop5: 'yellow',
+      prop6: 'black',
     },
   })
 })</code></pre>

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  'projectId': '4b7344',
+  projectId: '4b7344',
   e2e: {},
 }

--- a/cypress/e2e/2-advanced-examples/actions.cy.js
+++ b/cypress/e2e/2-advanced-examples/actions.cy.js
@@ -17,9 +17,9 @@ context('Actions', () => {
     cy.get('.action-email').type('{del}{selectall}{backspace}')
 
     // .type() with key modifiers
-    cy.get('.action-email').type('{alt}{option}') //these are equivalent
-    cy.get('.action-email').type('{ctrl}{control}') //these are equivalent
-    cy.get('.action-email').type('{meta}{command}{cmd}') //these are equivalent
+    cy.get('.action-email').type('{alt}{option}') // these are equivalent
+    cy.get('.action-email').type('{ctrl}{control}') // these are equivalent
+    cy.get('.action-email').type('{meta}{command}{cmd}') // these are equivalent
     cy.get('.action-email').type('{shift}')
 
     // Delay each keypress by 0.1 sec

--- a/cypress/e2e/2-advanced-examples/cypress_api.cy.js
+++ b/cypress/e2e/2-advanced-examples/cypress_api.cy.js
@@ -1,7 +1,6 @@
 /// <reference types="cypress" />
 
 context('Cypress APIs', () => {
-
   context('Cypress.Commands', () => {
     beforeEach(() => {
       cy.visit('http://localhost:8080/cypress-api')

--- a/cypress/e2e/2-advanced-examples/misc.cy.js
+++ b/cypress/e2e/2-advanced-examples/misc.cy.js
@@ -43,7 +43,8 @@ context('Misc', () => {
     if (Cypress.platform === 'win32') {
       cy.exec(`print ${Cypress.config('configFile')}`)
         .its('stderr').should('be.empty')
-    } else {
+    }
+    else {
       cy.exec(`cat ${Cypress.config('configFile')}`)
         .its('stderr').should('be.empty')
 

--- a/cypress/e2e/2-advanced-examples/storage.cy.js
+++ b/cypress/e2e/2-advanced-examples/storage.cy.js
@@ -64,9 +64,9 @@ context('Local Storage / Session Storage', () => {
       expect(storageMap).to.deep.equal({
         // other origins will also be present if localStorage is set on them
         'http://localhost:8080': {
-          'prop1': 'red',
-          'prop2': 'blue',
-          'prop3': 'magenta',
+          prop1: 'red',
+          prop2: 'blue',
+          prop3: 'magenta',
         },
       })
     })
@@ -94,9 +94,9 @@ context('Local Storage / Session Storage', () => {
       expect(storageMap).to.deep.equal({
         // other origins will also be present if sessionStorage is set on them
         'http://localhost:8080': {
-          'prop4': 'cyan',
-          'prop5': 'yellow',
-          'prop6': 'black',
+          prop4: 'cyan',
+          prop5: 'yellow',
+          prop6: 'black',
         },
       })
     })

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,18 +10,18 @@ export default [
   ...eslintPluginJsonc.configs['flat/recommended-with-json'],
   mochaPlugin.configs.recommended,
   pluginCypress.configs.recommended,
+  stylistic.configs.recommended,
   {
-    ignores: ['app/assets/js/vendor/'],
+    ignores: ['app/assets/js/{vendor,todo}/'],
   },
   {
-    plugins: {
-      '@stylistic': stylistic,
-    },
     rules: {
-      '@stylistic/indent': ['error', 2, { 'SwitchCase': 1, 'MemberExpression': 'off' }],
+      '@stylistic/arrow-parens': ['error', 'always'],
       '@stylistic/comma-dangle': ['error', 'always-multiline'],
+      '@stylistic/indent': ['error', 2, { SwitchCase: 1, MemberExpression: 'off' }],
       '@stylistic/quotes': ['error', 'single'],
       '@stylistic/semi': ['error', 'never'],
+      '@stylistic/space-before-function-paren': ['error', 'always'],
       'mocha/no-exclusive-tests': 'error',
       'mocha/no-pending-tests': 'error',
       'mocha/no-mocha-arrows': 'off',

--- a/scripts/set-port.js
+++ b/scripts/set-port.js
@@ -26,7 +26,6 @@ const newUrl = `localhost:${process.env.PORT}`
 
 console.log('replacing "%s" with "%s" in all spec files', input, newUrl)
 
-
 const getSpecFilenames = () => {
   const globby = require('globby')
 


### PR DESCRIPTION
## Situation

Examples are currently stylistically linted according to [@stylistic/eslint-plugin](https://eslint.style/) to lint styling in the repo according to the configuration in [eslint.config.mjs](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/eslint.config.mjs) which specifies:

```js
    plugins: {
      '@stylistic': stylistic,
    },
    rules: {
      '@stylistic/indent': ['error', 2, { 'SwitchCase': 1, 'MemberExpression': 'off' }],
      '@stylistic/comma-dangle': ['error', 'always-multiline'],
      '@stylistic/quotes': ['error', 'single'],
      '@stylistic/semi': ['error', 'never'],
```

The rules marked as Recommended in [eslint-plugin/rules.md](https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules.md) are not applied as a group.

## Change

- Apply rule configuration `stylistic.configs.recommended`

- Add the following rules for consistency with Cypress coding conventions:

  - `'@stylistic/arrow-parens': ['error', 'always']`
  - `'@stylistic/space-before-function-paren': ['error', 'always']`

- Ignore also [app/assets/js/todo/](https://github.com/cypress-io/cypress-example-kitchensink/tree/master/app/assets/js/todo) as this is an imported third-party app

- Use `npx eslint --fix` to auto-fix. These are white-space and quote usage changes.

- Manually map the auto-fix changes into the [app](https://github.com/cypress-io/cypress-example-kitchensink/tree/master/app).

## Test

Execute the following and confirm that no errors are reported and no changes are suggested:

```shell
git clean -xfd
npm ci
npx eslint
npm run test:ci
```

The following warning is a separate issue caused by transient dependencies including `typescript` and Cypress incorrectly assuming that this is a TypeScript project:

> Couldn't find tsconfig.json. tsconfig-paths will be skipped
