### PR TITLE
feat: add cy.exec() Cypress 15 misc test compatibility

### DIFF
--- a/app/commands/misc.html
+++ b/app/commands/misc.html
@@ -129,7 +129,8 @@ else {
     .its('stderr').should('be.empty')
 
   cy.exec('pwd')
-    .its('code').should('eq', 0)
+    // for Cypress 14 and below, use 'code' instead of 'exitCode'
+    .its('exitCode').should('eq', 0)
 }</code></pre>
         </div>
 

--- a/cypress/e2e/2-advanced-examples/misc.cy.js
+++ b/cypress/e2e/2-advanced-examples/misc.cy.js
@@ -1,4 +1,5 @@
 /// <reference types="cypress" />
+const semver = require('semver')
 
 context('Misc', () => {
   beforeEach(() => {
@@ -48,8 +49,14 @@ context('Misc', () => {
       cy.exec(`cat ${Cypress.config('configFile')}`)
         .its('stderr').should('be.empty')
 
-      cy.exec('pwd')
-        .its('code').should('eq', 0)
+      if (semver.lt(Cypress.version, '15.0.0')) {
+        cy.exec('pwd')
+          .its('code').should('eq', 0)
+      }
+      else {
+        cy.exec('pwd')
+          .its('exitCode').should('eq', 0)
+      }
     }
   })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "globby": "11.1.0",
         "husky": "9.0.6",
         "semantic-release": "24.2.6",
+        "semver": "7.7.2",
         "start-server-and-test": "2.0.11",
         "yaml-lint": "1.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "globby": "11.1.0",
     "husky": "9.0.6",
     "semantic-release": "24.2.6",
+    "semver": "7.7.2",
     "start-server-and-test": "2.0.11",
     "yaml-lint": "1.7.0"
   },


### PR DESCRIPTION
- supersedes https://github.com/cypress-io/cypress-example-kitchensink/pull/983

## Situation

PR https://github.com/cypress-io/cypress/pull/32238 plans to update [execa](https://www.npmjs.com/package/execa) in Cypress from [execa@1.0.0](https://github.com/sindresorhus/execa/releases/tag/v1.0.0) to [execa@4.1.0](https://github.com/sindresorhus/execa/releases/tag/v4.1.0) and for [cy.exec()](https://docs.cypress.io/api/commands/exec#Yields) to yield property `exitCode` instead of `exit`.

PR https://github.com/cypress-io/cypress-example-kitchensink/pull/983 currently proposes to convert
[cypress/e2e/2-advanced-examples/misc.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/2-advanced-examples/misc.cy.js) from using

- `code` (Cypress 14 and below) to instead
- `exitCode` (Cypress 15 - currently unreleased)

causing a breaking change, in that the repo will then fail for Cypress 14, and scaffolded tests will also fail if a project is installed with Cypress 15 and then downgraded to Cypress 14 or below.

## Change

In the test "'cy.exec() - execute a system command'" of [cypress/e2e/2-advanced-examples/misc.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/2-advanced-examples/misc.cy.js), use [Cypress.version](https://docs.cypress.io/api/cypress-api/version) to provide two different versions of `cy.exec('pwd')` appropriate for Cypress 14 and below, and for Cypress 15 respectively.

For publication on https://example.cypress.io/commands/misc update [app/commands/misc.html](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/app/commands/misc.html) to use Cypress 15 syntax with a comment to use `code` for Cypress 14 and below.

Add the npm package [semver@7.7.2](https://github.com/npm/node-semver/releases/tag/v7.7.2) to `devDependencies`. This is not essential, just good practice. Cypress already includes `semver` as a dependency (see https://www.npmjs.com/package/cypress?activeTab=dependencies) and so it is available anyway.

## Verification

On Ubuntu `24.04.3` LTS, Node.js `22.18.0` LTS

```shell
git clone https://github.com/cypress-io/cypress-example-kitchensink
cd cypress-example-kitchensink
npm ci
npm run start
```

In a separate terminal

```shell
npx cypress run -s cypress/e2e/2-advanced-examples/misc.cy.js
```

Confirm that all tests run.

```shell
git clone https://github.com/cypress-io/cypress
cd cypress
git switch breaking/update_execa
yarn
yarn cypress:run --project ../cypress-example-kitchensink -s ../cypress-example-kitchensink/cypress/e2e/2-advanced-examples/misc.cy.js
```

Copy the test spec changes into a project scaffolded with Cypress 14 and confirm that tests run with no need to install `semver` separately.

```text
--- a/cypress/e2e/2-advanced-examples/misc.cy.js
+++ b/cypress/e2e/2-advanced-examples/misc.cy.js
@@ -1,4 +1,5 @@
 /// <reference types="cypress" />
+const semver = require('semver')

 context('Misc', () => {
   beforeEach(() => {
@@ -48,8 +49,14 @@ context('Misc', () => {
       cy.exec(`cat ${Cypress.config('configFile')}`)
         .its('stderr').should('be.empty')

-      cy.exec('pwd')
-        .its('code').should('eq', 0)
+      if (semver.lt(Cypress.version, '15.0.0')) {
+        cy.exec('pwd')
+          .its('code').should('eq', 0)
+      }
+      else {
+        cy.exec('pwd')
+          .its('exitCode').should('eq', 0)
+      }
     }
   })
```
