### PR TITLE
fix(docs): correct dead links in commands pages

### DIFF
--- a/app/commands/assertions.html
+++ b/app/commands/assertions.html
@@ -136,7 +136,7 @@ cy.get('.assertion-table')
   .should('be.visible')</code></pre>
 
             <p>Note: find even more examples of matching element's text content in this
-              <a href="https://on.cypress.io/using-cypress-faq#How-do-I-get-an-element’s-text-contents" target="_blank">FAQ answer</a>.
+              <a href="https://docs.cypress.io/app/faq#How-do-I-get-an-elements-text-contents" target="_blank">FAQ answer</a>.
             </p>
           </div>
           <div class="col-xs-5">

--- a/app/commands/spies-stubs-clocks.html
+++ b/app/commands/spies-stubs-clocks.html
@@ -44,7 +44,7 @@
               <li><a href="/commands/aliasing">Aliasing</a></li>
               <li><a href="/commands/waiting">Waiting</a></li>
               <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/fixtures">Fixtures</a></li>
+              <li><a href="/commands/files">Files</a></li>
               <li><a href="/commands/storage">Storage</a></li>
               <li><a href="/commands/cookies">Cookies</a></li>
               <li class="active"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>


### PR DESCRIPTION
## Situation

Links on web pages sourced from this repo cause HTTP 404 not found errors:

| Page                                                   | Link                                         | Error |
| ------------------------------------------------------ | -------------------------------------------- | ----- |
| https://example.cypress.io/commands/spies-stubs-clocks | https://example.cypress.io/commands/fixtures | 404   |
| https://example.cypress.io/commands/assertions         | https://on.cypress.io/using-cypress-faq      | 404   |

## Change

| Published page                                         | Source                                                                                                                                             | Original Link                                | New Link                                                               |
| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------- |
| https://example.cypress.io/commands/spies-stubs-clocks | [app/commands/spies-stubs-clocks.html](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/app/commands/spies-stubs-clocks.html) | https://example.cypress.io/commands/fixtures | https://example.cypress.io/commands/files                              |
| https://example.cypress.io/commands/assertions         | [app/commands/assertions.html](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/app/commands/assertions.html)                 | https://on.cypress.io/using-cypress-faq      | https://docs.cypress.io/app/faq#How-do-I-get-an-elements-text-contents |

## Verification

```shell
npm ci
npm start
```

In web browser, open

- http://localhost:8080/commands/spies-stubs-clocks, click on Commands > Files and confirm that http://localhost:8080/commands/files opens, showing documentation for `cy.fixture()`
<img width="549" height="567" alt="image" src="https://github.com/user-attachments/assets/a84ea0f7-06c3-4f31-88df-dfa478ac6cf3" />

---

<img width="517" height="366" alt="image" src="https://github.com/user-attachments/assets/1edb6271-4b44-4e08-8d8e-6ad8efcf5e4c" />


- http://localhost:8080/commands/assertions, click on link "FAQ answer" and confirm that [How do I get an element's text contents?](https://docs.cypress.io/app/faq#How-do-I-get-an-elements-text-contents) is opened and displayed

<img width="776" height="1004" alt="image" src="https://github.com/user-attachments/assets/ea5bc87d-fe5c-430a-8bc3-a9b8488672cd" />

---

<img width="959" height="322" alt="image" src="https://github.com/user-attachments/assets/e05f55f2-fec9-4592-b8df-672f002b4fc6" />
