### PR TITLE
ci: add max_auto_reruns to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@
 version: 2.1
 orbs:
   # use Cypress orb from CircleCI registry
-  cypress: cypress-io/cypress@4.1.0
+  cypress: cypress-io/cypress@5.0.1 # https://github.com/cypress-io/circleci-orb/releases
   win: circleci/windows@5.1.0
 
 executors:
@@ -170,7 +170,7 @@ jobs:
     parallelism: 3
     executor:
       name: cypress/default
-      node-version: '22.15.0'
+      node-version: '22.20.0'
     steps:
       - cypress/install:
           post-install: 'npm run build'
@@ -192,7 +192,7 @@ jobs:
     parallelism: 2
     executor:
       name: cypress/default
-      node-version: '22.15.0'
+      node-version: '22.20.0'
     steps:
       - cypress/install:
           install-browsers: true
@@ -205,7 +205,7 @@ jobs:
     parallelism: 2
     executor:
       name: cypress/default
-      node-version: '22.15.0'
+      node-version: '22.20.0'
     steps:
       - cypress/install:
           install-browsers: true
@@ -216,7 +216,7 @@ jobs:
   release:
     executor:
       name: cypress/default
-      node-version: '22.15.0'
+      node-version: '22.20.0'
     steps:
       - checkout
       - run: npm ci
@@ -234,6 +234,7 @@ workflows:
       - mac-test
 
   linux-build:
+    max_auto_reruns: 3
     jobs:
       - linux-test
       - linux-test-chrome


### PR DESCRIPTION
## Situation

The workflow job `linux-test` continually and sporadically fails, such as in https://app.circleci.com/pipelines/github/cypress-io/cypress-example-kitchensink/2186/workflows/65521548-b563-4cd1-a0f7-c8de87f738cb/jobs/15073 with

```text
Cypress failed to start.

This may be due to a missing library or dependency. https://on.cypress.io/required-dependencies

Please refer to the error below for more details.

----------

[175:0929/051224.384148:ERROR:dbus/bus.cc:408] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
[175:0929/051225.040924:ERROR:ui/ozone/platform/x11/ozone_platform_x11.cc:250] Missing X server or $DISPLAY
[175:0929/051225.040981:ERROR:ui/aura/env.cc:257] The platform failed to initialize.  Exiting.

----------

Platform: linux-x64 (Ubuntu - 22.04)
Cypress Version: 15.0.0

Exited with code exit status 1
```

In this example "Spin up environment" took 1m 30s, compared to 15s in a comparable non-error condition.

## Assessment

The workflow selects an executor `cypress/default` with a `node-version` specified to [Cypress CircleCI Orb](https://circleci.com/developer/orbs/orb/cypress-io/cypress) using a Docker image. This currently spins up `docker.io/cimg/node:22.15.0-browsers` built in the [CircleCI-Public/cimg-node](https://github.com/CircleCI-Public/cimg-node) repo. For `cimg:node:*-browsers` variants, the Docker image is built with the `entrypoint` script `/docker-entrypoint.sh` containing:

```shell
#!/bin/sh
Xvfb :99 -screen 0 1280x1024x24 &
exec "$@"
```

which attempts to start an `Xvfb` server when the Docker container is started.

The assumption is that the CircleCI infrastructure is suffering from an overload, causing it to provide an X11 `DISPLAY` environment variable without the corresponding Xvfb server from the [cimg/node](https://circleci.com/developer/images/image/cimg/node) Docker image having completed its start-up.

## Change

In the CircleCI configuration [.circleci/config.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.circleci/config.yml):

- Apply CircleCI [Automatic reruns](https://circleci.com/docs/guides/orchestrate/automatic-reruns/) to the workflow `linux-build`:

```yml
  linux-build:
    max_auto_reruns: 3
    jobs:
      - linux-test
      - linux-test-chrome
      - linux-test-firefox
```

A step re-run is not available, because this needs the CircleCI key `command`, whereas `cypress-command` is being used to execute `cypress run`.

- Update [Cypress CircleCI Orb](https://circleci.com/developer/orbs/orb/cypress-io/cypress) from [4.1.0](https://github.com/cypress-io/circleci-orb/releases/tag/v4.1.0) to [5.0.1](https://github.com/cypress-io/circleci-orb/releases/tag/v5.0.1)

- Update `node-version` to `22.20.0` (Active LTS) in Linux-based jobs, for parity with Windows and macOS jobs that specify Node.js `22` installation through `nvm`.

## Related

- https://github.com/cypress-io/circleci-orb/issues/538
- https://discuss.circleci.com/t/xvfb-frequently-fails-to-start-with-browsers-convenience-image/53164
- https://github.com/cypress-io/cypress/issues/31484
