### PR TITLE
chore: use npm credentials context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,6 +240,7 @@ workflows:
       - linux-test-firefox
 
       - release:
+          context: org-npm-credentials
           filters:
             branches:
               only:


### PR DESCRIPTION
uses new npm context to more easily adhere to token rotation