### PR TITLE
ci: update CircleCI config to Node.js 24.11.0 Active LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
           name: Install Node.js
           command: |
             nvm --version
-            nvm install 22
-            nvm use 22
+            nvm install 24.11.0
+            nvm use 24.11.0
       - restore_cache:
           key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
 
@@ -70,8 +70,8 @@ jobs:
           name: Install Node.js
           command: |
             nvm --version
-            nvm install 22
-            nvm use 22
+            nvm install 24.11.0
+            nvm use 24.11.0
       - restore_cache:
           key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
 
@@ -113,8 +113,8 @@ jobs:
           name: Install Node.js
           command: |
             nvm --version
-            nvm install 22
-            nvm use 22
+            nvm install 24.11.0
+            nvm use 24.11.0
       - restore_cache:
           key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
 
@@ -150,8 +150,8 @@ jobs:
       - run:
           name: Install Node.js
           command: |
-            nvm install 22
-            nvm use 22
+            nvm install 24.11.0
+            nvm use 24.11.0
       - cypress/install:
           post-install: "npm run build"
       # show Cypress cache folder and binary versions
@@ -170,7 +170,7 @@ jobs:
     parallelism: 3
     executor:
       name: cypress/default
-      node-version: '22.20.0'
+      node-version: '24.11.0'
     steps:
       - cypress/install:
           post-install: 'npm run build'
@@ -192,7 +192,7 @@ jobs:
     parallelism: 2
     executor:
       name: cypress/default
-      node-version: '22.20.0'
+      node-version: '24.11.0'
     steps:
       - cypress/install:
           install-browsers: true
@@ -205,7 +205,7 @@ jobs:
     parallelism: 2
     executor:
       name: cypress/default
-      node-version: '22.20.0'
+      node-version: '24.11.0'
     steps:
       - cypress/install:
           install-browsers: true
@@ -216,7 +216,7 @@ jobs:
   release:
     executor:
       name: cypress/default
-      node-version: '22.20.0'
+      node-version: '24.11.0'
     steps:
       - checkout
       - run: npm ci


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-example-kitchensink/issues/999

## Situation

The [.circleci](https://github.com/cypress-io/cypress-example-kitchensink/tree/master/.circleci) configuration is the main CI component in this example repo, used for test and release of the [cypress-example-kitchensink](https://www.npmjs.com/package/cypress-example-kitchensink) npm package.

1. It uses Node.js 22, which has now transitioned into Maintenance LTS status, replaced by Node.js 24 as Active LTS - see [Node.js Release schedule](https://github.com/nodejs/release#release-schedule).
2. Without there having been any changes to the config, the `mac-test` job has started to fail, with nvm completing successfully and apparently failing to install the selected Node.js version with packaged npm.

## Change

Update the [.circleci](https://github.com/cypress-io/cypress-example-kitchensink/tree/master/.circleci) configuration to use [Node.js 24.11.0](https://nodejs.org/en/blog/release/v24.11.0) as the Active LTS version. For more predictable results, the full version `24.11.0` of Node.js is pinned, rather than the generic `24`.
