### PR TITLE
ci(deps): update CircleCI cypress-io/cypress orb to 6.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@
 version: 2.1
 orbs:
   # use Cypress orb from CircleCI registry
-  cypress: cypress-io/cypress@5.0.1 # https://github.com/cypress-io/circleci-orb/releases
+  cypress: cypress-io/cypress@6.0.0 # https://github.com/cypress-io/circleci-orb/releases
   win: circleci/windows@5.1.0
 
 executors:


### PR DESCRIPTION
## Situation

The main CircleCI configuration [.circleci/config.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.circleci/config.yml) uses the [cypress-io/cypress@5.0.1](https://github.com/cypress-io/circleci-orb/releases/tag/v5.0.1) CircleCI orb which is no longer the latest version.

## Change

Update the [.circleci/config.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.circleci/config.yml) configuration

| From                                                                                       | To                                                                                         |
| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
| [cypress-io/cypress@5.0.1](https://github.com/cypress-io/circleci-orb/releases/tag/v5.0.1) | [cypress-io/cypress@6.0.0](https://github.com/cypress-io/circleci-orb/releases/tag/v6.0.0) |
