### PR TITLE
chore: migrate and fix Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,9 @@
 {
+  "configMigration": true,
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "automerge": true,
-  "commitMessage": "{{semanticPrefix}}Update {{depName}} to {{newVersion}} 🌟",
-  "prTitle": "{{semanticPrefix}}{{#if isPin}}Pin{{else}}Update{{/if}} dependency {{depName}} to version {{newVersion}} 🌟",
   "major": {
     "automerge": false
   },
@@ -21,21 +20,20 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "separatePatchReleases": true,
+  "separateMinorPatch": true,
   "separateMultipleMajor": true,
-  "masterIssue": true,
   "labels": [
     "type: dependencies",
     "renovate"
   ],
   "packageRules": [
     {
-      "packageNames": ["cypress"],
+      "matchPackageNames": ["cypress"],
       "groupName": "cypress",
       "schedule": "before 2am"
     },
     {
-      "packagePatterns": "^eslint",
+      "matchPackageNames": ["eslint", "globals"],
       "groupName": "eslint"
     }
   ]


### PR DESCRIPTION
## Situation

The Renovate [Dependency Dashboard](https://github.com/cypress-io/cypress-example-kitchensink/issues/176) indicates:

> ## Config Migration Needed
> * [ ]   Select this checkbox to let Renovate create an automated Config Migration PR.
>
> ## Repository problems
> These problems occurred while renovating this repository. [View logs](https://developer.mend.io//github/cypress-io/cypress-example-kitchensink).
>
> * WARN: Found renovate config warnings

The [renovate.json](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/renovate.json) configuration was last updated 6 years ago in March 2019.

Applying [Config Validation](https://docs.renovatebot.com/config-validation/) by executing:

```shell
npx --yes --package renovate -- renovate-config-validator
```

shows the following:

```text
$ npx --yes --package renovate -- renovate-config-validator
 INFO: Validating renovate.json
 WARN: Config migration necessary
       "oldConfig": {
         "extends": ["config:base"],
         "automerge": true,
         "commitMessage": "{{semanticPrefix}}Update {{depName}} to {{newVersion}} 🌟",
         "prTitle": "{{semanticPrefix}}{{#if isPin}}Pin{{else}}Update{{/if}} dependency {{depName}} to version {{newVersion}} 🌟",
         "major": {"automerge": false},
         "minor": {"automerge": false},
         "prConcurrentLimit": 3,
         "prHourlyLimit": 2,
         "schedule": ["after 2am and before 3am on saturday"],
         "updateNotScheduled": false,
         "timezone": "America/New_York",
         "lockFileMaintenance": {"enabled": true},
         "separatePatchReleases": true,
         "separateMultipleMajor": true,
         "masterIssue": true,
         "labels": ["type: dependencies", "renovate"],
         "packageRules": [
           {
             "packageNames": ["cypress"],
             "groupName": "cypress",
             "schedule": "before 2am"
           },
           {"packagePatterns": "^eslint", "groupName": "eslint"}
         ]
       },
       "newConfig": {
         "extends": ["config:recommended"],
         "automerge": true,
         "commitMessage": "{{#if semanticCommitType}}{{semanticCommitType}}{{#if semanticCommitScope}}({{semanticCommitScope}}){{/if}}: {{/if}}Update {{depName}} to {{newVersion}} 🌟",
         "prTitle": "{{#if semanticCommitType}}{{semanticCommitType}}{{#if semanticCommitScope}}({{semanticCommitScope}}){{/if}}: {{/if}}{{#if isPin}}Pin{{else}}Update{{/if}} dependency {{depName}} to version {{newVersion}} 🌟",
         "major": {"automerge": false},
         "minor": {"automerge": false},
         "prConcurrentLimit": 3,
         "prHourlyLimit": 2,
         "schedule": ["after 2am and before 3am on saturday"],
         "updateNotScheduled": false,
         "timezone": "America/New_York",
         "lockFileMaintenance": {"enabled": true},
         "separateMinorPatch": true,
         "separateMultipleMajor": true,
         "dependencyDashboard": true,
         "labels": ["type: dependencies", "renovate"],
         "packageRules": [
           {
             "matchPackageNames": ["cypress"],
             "groupName": "cypress",
             "schedule": "before 2am"
           },
           {"groupName": "eslint", "matchPackageNames": ["/^eslint/"]}
         ]
       }
 WARN: Found errors in configuration
       "file": "renovate.json",
       "warnings": [
         {
           "topic": "Deprecation Warning",
           "message": "Direct editing of commitMessage is now deprecated. Please edit commitMessage's subcomponents instead."
         },
         {
           "topic": "Deprecation Warning",
           "message": "Direct editing of prTitle is now deprecated. Please edit commitMessage subcomponents instead as they will be passed through to prTitle."
         }
       ]
```

## Change

Update [renovate.json](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/renovate.json) according to recommendations from [Renovate Config Validation](https://docs.renovatebot.com/config-validation/).

1. Convert `config:base` to new name `config:recommended`
2. Remove the deprecated [commitMessage](https://docs.renovatebot.com/configuration-options/#commitmessage) and [prTitle](https://docs.renovatebot.com/configuration-options/#prtitle) options. The defaults now provide adequate messages.
3. Remove `masterIssue`. This was replaced by [dependencyDashboard](https://docs.renovatebot.com/configuration-options/#dependencydashboard) and it is selected by default with [config:recommended](https://docs.renovatebot.com/presets-config/#configrecommended).
4. Convert `separatePatchReleases` to [separateMinorPatch](https://docs.renovatebot.com/configuration-options/#separateminorpatch)
5. Convert `packageNames` and `packagePatterns` to [matchPackageNames](https://docs.renovatebot.com/configuration-options/#matchpackagenames)
6. Change `^eslint` to `eslint` to match all ESLint related packages and add `globals`.
7. Add [configMigration](https://docs.renovatebot.com/configuration-options/#configmigration) `true` to automatically create config migration PRs when needed.

## Verification

Execute

```shell
npx --yes --package renovate -- renovate-config-validator
```

and confirm output:

```text
 INFO: Validating renovate.json
 INFO: Config validated successfully
```

## Reference

- [config:recommended](https://docs.renovatebot.com/presets-config/#configrecommended)
- [Config Validation](https://docs.renovatebot.com/config-validation/)
- [commitMessage](https://docs.renovatebot.com/configuration-options/#commitmessage)
- [configMigration](https://docs.renovatebot.com/configuration-options/#configmigration)
- [dependencyDashboard](https://docs.renovatebot.com/configuration-options/#dependencydashboard)
- [matchPackageNames](https://docs.renovatebot.com/configuration-options/#matchpackagenames)
- [prTitle](https://docs.renovatebot.com/configuration-options/#prtitle)
- [separateMinorPatch](https://docs.renovatebot.com/configuration-options/#separateminorpatch)
