### PR TITLE
ci(deps): update CircleCI to xcode 16.4.0 / resource class m4pro.medium

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,8 @@ orbs:
 executors:
   mac:
     macos:
-      xcode: "16.2.0"
-    resource_class: macos.m1.medium.gen1
+      xcode: "16.4.0"
+    resource_class: m4pro.medium
 
 jobs:
   win-test:


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-example-kitchensink/issues/1006

## Situation

CircleCI announced [Deprecation of Mac M1 and M2 resource classes](https://circleci.com/changelog/deprecation-of-mac-m1-and-m2-resource-classes/) on Oct 15, 2025, with brownouts planned for Dec 2025 & Jan 2026 and removal on Feb 16, 2026.

The CircleCI config [.circleci/config.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.circleci/config.yml) uses [xcode machine image](https://circleci.com/developer/machine/image/xcode) [16.2.0](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v15180/manifest.txt), using macOS `14.6.1` with resource class `macos.m1.medium.gen1`.

## Change

Update to latest `xcode` `16.x` version `16.4.0` from [Supported Xcode versions for Apple silicon](https://circleci.com/docs/guides/test/testing-ios/#supported-xcode-versions-silicon) using macOS `15.3.2`.

Migrate away from the CircleCI [macOS execution environment](https://circleci.com/docs/reference/configuration-reference/#macos-execution-environment) deprecated resource class using `macos.m1.medium.gen1` to use instead the resource class `m4pro.medium` explicitly.
