### PR TITLE
chore(deps): update ci examples to Node.js 24.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
           name: Install Node.js
           command: |
             nvm --version
-            nvm install 24.11.0
-            nvm use 24.11.0
+            nvm install 24.13.0
+            nvm use 24.13.0
       - restore_cache:
           key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
 
@@ -70,8 +70,8 @@ jobs:
           name: Install Node.js
           command: |
             nvm --version
-            nvm install 24.11.0
-            nvm use 24.11.0
+            nvm install 24.13.0
+            nvm use 24.13.0
       - restore_cache:
           key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
 
@@ -113,8 +113,8 @@ jobs:
           name: Install Node.js
           command: |
             nvm --version
-            nvm install 24.11.0
-            nvm use 24.11.0
+            nvm install 24.13.0
+            nvm use 24.13.0
       - restore_cache:
           key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
 
@@ -150,9 +150,9 @@ jobs:
       - run:
           name: Install Node.js
           command: |
-            nvm install 24.11.0
-            nvm use 24.11.0
-            nvm alias default 24.11.0
+            nvm install 24.13.0
+            nvm use 24.13.0
+            nvm alias default 24.13.0
       - cypress/install:
           post-install: "npm run build"
       # show Cypress cache folder and binary versions
@@ -171,7 +171,7 @@ jobs:
     parallelism: 3
     executor:
       name: cypress/default
-      node-version: '24.11.0'
+      node-version: '24.13.0'
     steps:
       - cypress/install:
           post-install: 'npm run build'
@@ -193,7 +193,7 @@ jobs:
     parallelism: 2
     executor:
       name: cypress/default
-      node-version: '24.11.0'
+      node-version: '24.13.0'
     steps:
       - cypress/install:
           install-browsers: true
@@ -206,7 +206,7 @@ jobs:
     parallelism: 2
     executor:
       name: cypress/default
-      node-version: '24.11.0'
+      node-version: '24.13.0'
     steps:
       - cypress/install:
           install-browsers: true
@@ -217,7 +217,7 @@ jobs:
   release:
     executor:
       name: cypress/default
-      node-version: '24.11.0'
+      node-version: '24.13.0'
     steps:
       - checkout
       - run: npm ci

--- a/.github/workflows/chrome-docker.yml
+++ b/.github/workflows/chrome-docker.yml
@@ -7,7 +7,7 @@ jobs:
   chrome:
     runs-on: ubuntu-24.04
     # https://github.com/cypress-io/cypress-docker-images
-    container: cypress/browsers:24.11.0
+    container: cypress/browsers:24.13.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ cache:
 
 # this job installs npm dependencies and Cypress
 install:
-  image: cypress/base:24.11.0
+  image: cypress/base:24.13.0
   stage: build
 
   script:
@@ -35,7 +35,7 @@ install:
 
 # all jobs that actually run tests can use the same definition
 .job_template:
-  image: cypress/base:24.11.0
+  image: cypress/base:24.13.0
   stage: test
   script:
     # print CI environment variables for reference

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://documentation.codeship.com/pro/languages-frameworks/nodejs/
 
 # use Cypress provided image with all dependencies included
-FROM cypress/base:24.11.0
+FROM cypress/base:24.13.0
 RUN node --version
 RUN npm --version
 WORKDIR /home/node/app

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
   agent {
     // this image provides everything needed to run Cypress
     docker {
-      image 'cypress/base:24.11.0'
+      image 'cypress/base:24.13.0'
     }
   }
 

--- a/basic/.circleci/config.yml
+++ b/basic/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: cypress/base:24.11.0
+      - image: cypress/base:24.13.0
     steps:
       - checkout
       # restore folders with npm dependencies and Cypress binary

--- a/basic/.gitlab-ci.yml
+++ b/basic/.gitlab-ci.yml
@@ -13,7 +13,7 @@ cache:
     - cache/Cypress
 
 test:
-  image: cypress/base:24.11.0
+  image: cypress/base:24.13.0
   stage: test
   script:
     - npm ci

--- a/basic/Jenkinsfile
+++ b/basic/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
   agent {
     // this image provides everything needed to run Cypress
     docker {
-      image 'cypress/base:24.11.0'
+      image 'cypress/base:24.13.0'
     }
   }
 

--- a/basic/codeship-pro/Dockerfile
+++ b/basic/codeship-pro/Dockerfile
@@ -2,7 +2,7 @@
 # https://documentation.codeship.com/pro/languages-frameworks/nodejs/
 
 # use Cypress provided image with all dependencies included
-FROM cypress/base:24.11.0
+FROM cypress/base:24.13.0
 RUN node --version
 RUN npm --version
 WORKDIR /home/node/app

--- a/buddy.yml
+++ b/buddy.yml
@@ -8,7 +8,7 @@
       type: "BUILD"
       working_directory: "/buddy/cypress-example-kitchensink"
       docker_image_name: "cypress/base"
-      docker_image_tag: "24.11.0"
+      docker_image_tag: "24.13.0"
       execute_commands:
         - "npm install --force"
         - "npm run cy:verify"


### PR DESCRIPTION
## Situation

Example workflows currently use either the generic Node.js 24 or specific version Node.js `24.11.0`.

CircleCI released a fix in the Docker image `cimg/node:24.13.0-browsers` that lessens the chance of a Cypress failure with the error message "Missing X server or $DISPLAY" (see closed issue https://github.com/cypress-io/circleci-orb/issues/538).

[Node.js 24.13.0](https://nodejs.org/en/blog/release/v24.13.0) is the Active LTS version at this time.

## Change

- Update example workflows to use Node.js `24.13.0` (or leave as-is using `24`, or `24.x` - depending on the CI provider)