### PR TITLE
chore: update Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,11 +12,6 @@
   },
   "prConcurrentLimit": 3,
   "prHourlyLimit": 2,
-  "schedule": [
-    "after 2am and before 3am on saturday"
-  ],
-  "updateNotScheduled": false,
-  "timezone": "America/New_York",
   "lockFileMaintenance": {
     "enabled": true
   },
@@ -28,12 +23,7 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": ["cypress"],
-      "groupName": "cypress",
-      "schedule": "before 2am"
-    },
-    {
-      "matchPackageNames": ["eslint", "globals"],
+      "matchPackageNames": ["/eslint/", "globals"],
       "groupName": "eslint"
     }
   ]


### PR DESCRIPTION
## Situation

https://developer.mend.io/github/cypress-io/cypress-example-kitchensink shows that a Renovate job is running regularly with 2 - 6 hour gaps between jobs.

All the jobs are listed under "Awaiting schedule" and are not running.

It looks like the 1 hour window

https://github.com/cypress-io/cypress-example-kitchensink/blob/a55531bd4acb73b4b3e8c5451bc79a6e5d9a4eb9/renovate.json#L15-L17

is too narrow. When the jobs run, they are mostly outside of this window.

The grouping for `eslint` does not match for `@eslint/*` `and eslint-plugin-*`

## Change

Since there doesn't seem to be a specific need to enforce a schedule, and Renovate is regularly firing up a job, remove the schedules. PRs will then be generated as needed.

Group any eslint type package together, changing to RegEx.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change; it may increase PR frequency/volume by removing schedule constraints and widening the eslint grouping match.
> 
> **Overview**
> Removes Renovate scheduling constraints (and related timezone/updateNotScheduled settings) so dependency PRs can be created whenever Renovate runs.
> 
> Updates the `eslint` package rule to match any eslint-related package via a regex (plus `globals`), and drops the dedicated `cypress` grouping rule.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08f5c913b668cbaf5d769d216fbff6098c5f8e61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->