### PR TITLE
ci: test only Chrome with AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,15 +39,8 @@ test_script:
   - npm run cy:info
   - npm run cy:cache:list
 
-  # noticed really slow execution of some specs on Windows
-  # leading to failures. Trying to increase the command timeout
-  # maybe it will solve it
   - setx CYPRESS_defaultCommandTimeout 20000
   - npm run test:ci:record:chrome
-  - npm run test:ci:record
-  # removed Firefox test due to flakiness in this environment
-  # - npm run test:ci:record:firefox
-  - npm run test:ci:record:edge
 
 # Don't actually build.
 build: off


### PR DESCRIPTION
## Situation

- Workflows in AppVeyor are experiencing sporadic rate-limiting issues from https://jsonplaceholder.cypress.io (HTTP 429 Too Many Requests) (example [build 53667883](https://ci.appveyor.com/project/cypress-io/cypress-example-kitchensink/builds/53667883)) causing workflow failures
- The [appveyor.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/appveyor.yml) workflow currently tests against Chrome, Electron & Edge sequentially.
- It is the longest running of all the active example workflows, typically running for up to ~13 minutes depending on caching status

## Change

Other CI providers already extensively test the app against each browser, including testing under Windows. It is sufficient for the AppVeyor example to demonstrate one browser in order to reduce complexity and workflow duration.

Remove the tests against Electron and Edge, leaving Chrome tests. The advantages are:
    - reduction in quantity of requests against https://jsonplaceholder.cypress.io, lowering the risk of encountering rate-limiting with HTTP 429 errors
    - reduction in workflow duration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only changes CI configuration; the main impact is reduced cross-browser coverage on AppVeyor (Electron/Edge no longer exercised there).
> 
> **Overview**
> AppVeyor’s `test_script` is simplified to run a single Cypress recorded run in Chrome (`npm run test:ci:record:chrome`) and no longer runs the additional recorded suites (previously including Electron/default and Edge).
> 
> This reduces AppVeyor job duration and external request volume while keeping linting and Cypress verification/info steps unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98b58102236f0300ff9b8838b4d6bbae8ed73a2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->