### PR TITLE
chore(deps): migrate from yaml-lint to eslint-plugin-yml

### DIFF
--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -9,68 +9,68 @@ jobs:
     name: Cypress test
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-    # install a specific version of Node using
-    # https://github.com/actions/setup-node
-    - name: Set up Node.js
-      uses: actions/setup-node@v6
-      with:
-        node-version-file: .node-version
+      # install a specific version of Node using
+      # https://github.com/actions/setup-node
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
 
-    # just so we learn about available environment variables GitHub provides
-    - name: Print env variables
-      run: |
-        npm i -g @bahmutov/print-env
-        print-env GITHUB
+      # just so we learn about available environment variables GitHub provides
+      - name: Print env variables
+        run: |
+          npm i -g @bahmutov/print-env
+          print-env GITHUB
 
-    # Restore the previous npm modules and Cypress binary archives.
-    # In case there's no previous cache the packages will be downloaded
-    # and saved automatically after the entire workflow successfully finishes.
-    # See https://github.com/actions/cache
-    - name: Cache node modules
-      uses: actions/cache@v5
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+      # Restore the previous npm modules and Cypress binary archives.
+      # In case there's no previous cache the packages will be downloaded
+      # and saved automatically after the entire workflow successfully finishes.
+      # See https://github.com/actions/cache
+      - name: Cache node modules
+        uses: actions/cache@v5
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
-    - name: Cache Cypress binary
-      uses: actions/cache@v5
-      with:
-        path: ~/.cache/Cypress
-        key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package-lock.json') }}
+      - name: Cache Cypress binary
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package-lock.json') }}
 
-    - name: install dependencies and verify Cypress
-      env:
-        # make sure every Cypress install prints minimal information
-        CI: 1
-      # print Cypress and OS info
-      run: |
-        npm ci
-        npx cypress verify
-        npx cypress info
-        npx cypress version
-        npx cypress version --component package
-        npx cypress version --component binary
-        npx cypress version --component electron
-        npx cypress version --component node
+      - name: install dependencies and verify Cypress
+        env:
+          # make sure every Cypress install prints minimal information
+          CI: 1
+        # print Cypress and OS info
+        run: |
+          npm ci
+          npx cypress verify
+          npx cypress info
+          npx cypress version
+          npx cypress version --component package
+          npx cypress version --component binary
+          npx cypress version --component electron
+          npx cypress version --component node
 
-    # Starts local server, then runs Cypress tests and records results on Cypress Cloud
-    - name: Cypress tests
-      run: npm run test:ci:record
-      env:
-        # place your secret record key at
-        # https://github.com/cypress-io/cypress-example-kitchensink/settings/secrets
-        CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}
-        TERM: xterm
+      # Starts local server, then runs Cypress tests and records results on Cypress Cloud
+      - name: Cypress tests
+        run: npm run test:ci:record
+        env:
+          # place your secret record key at
+          # https://github.com/cypress-io/cypress-example-kitchensink/settings/secrets
+          CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}
+          TERM: xterm
 
-    # Save screenshots as test artifacts
-    # https://github.com/actions/upload-artifact
-    - uses: actions/upload-artifact@v6
+      # Save screenshots as test artifacts
+      # https://github.com/actions/upload-artifact
+      - uses: actions/upload-artifact@v6
         # there might be no screenshots created when:
         # - there are no test failures
         # so only upload screenshots if previous step has failed
-      if: failure()
-      with:
-        name: screenshots
-        path: cypress/screenshots
+        if: failure()
+        with:
+          name: screenshots
+          path: cypress/screenshots

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
 npm run lint
-npm run lint:yaml

--- a/basic/buildspec.yml
+++ b/basic/buildspec.yml
@@ -20,5 +20,5 @@ phases:
       - npm run cy:info
   build:
     commands:
-        - npm run start &
-        - npx cypress run --record
+      - npm run start &
+      - npx cypress run --record

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,21 +4,21 @@ version: 0.2
 # https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html
 # Define 5 parallel builds to run using the "build-matrix"
 build-matrix:
-    static:
-      ignore-failure: false
-      env:
-        type: LINUX_CONTAINER
-    dynamic:
-      env:
-        variables:
-          WORKERS:
-            - 1
-            - 2
-            - 3
-            - 4
-            - 5
+  static:
+    ignore-failure: false
+    env:
+      type: LINUX_CONTAINER
+  dynamic:
+    env:
+      variables:
+        WORKERS:
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
         # Optional: Use Custom Public ECR Image as container
-        #image:
+        # image:
         #  - public.ecr.aws/your-namespace/image-name
 
 phases:
@@ -45,5 +45,5 @@ phases:
     # which is unique and can be used as the --ci-build-id for the Cypress Cloud
     # e.g. awsCodeBuild-cypress-kitchen-sink/AWSCodeBuild-a14fc8e3-b5d6-42f9-9067-345d48a8f0fd
     commands:
-        - npm run start &
-        - npx cypress run --record --parallel --ci-build-id $CODEBUILD_INITIATOR
+      - npm run start &
+      - npx cypress run --record --parallel --ci-build-id $CODEBUILD_INITIATOR

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,7 @@ import pluginMocha from 'eslint-plugin-mocha'
 import pluginCypress from 'eslint-plugin-cypress'
 import stylistic from '@stylistic/eslint-plugin'
 import json from '@eslint/json'
+import pluginYml from 'eslint-plugin-yml'
 
 export default defineConfig([
   globalIgnores(['app/assets/js/{vendor,todo}/']),
@@ -37,5 +38,17 @@ export default defineConfig([
     plugins: { json },
     language: 'json/json',
     extends: ['json/recommended'],
+  },
+  {
+    files: ['**/*.yml'],
+    plugins: { yml: pluginYml },
+    language: 'yml/yaml',
+    extends: ['yml/recommended'],
+    rules: {
+      'yml/indent': ['error', 2],
+      'yml/key-spacing': ['error', { beforeColon: false, afterColon: true }],
+      'yml/no-multiple-empty-lines': ['error', { max: 1 }],
+      'yml/spaced-comment': ['error', 'always'],
+    },
   },
 ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,12 +21,12 @@
         "eslint": "10.0.0",
         "eslint-plugin-cypress": "5.3.0",
         "eslint-plugin-mocha": "11.2.0",
+        "eslint-plugin-yml": "3.3.1",
         "globals": "17.3.0",
         "globby": "11.1.0",
         "husky": "9.0.6",
         "semantic-release": "25.0.2",
-        "start-server-and-test": "2.0.11",
-        "yaml-lint": "1.7.0"
+        "start-server-and-test": "2.0.11"
       },
       "engines": {
         "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -625,6 +625,19 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@ota-meshi/ast-token-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@ota-meshi/ast-token-store/-/ast-token-store-0.3.0.tgz",
+      "integrity": "sha512-XRO0zi2NIUKq2lUk3T1ecFSld1fMWRKE6naRFGkgkdeosx7IslyUKNv5Dcb5PJTja9tHJoFu0v/7yEpAkrkrTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -1596,13 +1609,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2500,13 +2506,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/consola": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
@@ -2792,6 +2791,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dir-glob": {
@@ -3273,6 +3282,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-yml": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-yml/-/eslint-plugin-yml-3.3.1.tgz",
+      "integrity": "sha512-isntsZchaTqDMNNkD+CakrgA/pdUoJ45USWBKpuqfAW1MCuw731xX/vrXfoJFZU3tTFr24nCbDYmDfT2+g4QtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/core": "^1.0.1",
+        "@eslint/plugin-kit": "^0.6.0",
+        "@ota-meshi/ast-token-store": "^0.3.0",
+        "debug": "^4.3.2",
+        "diff-sequences": "^29.0.0",
+        "escape-string-regexp": "5.0.0",
+        "natural-compare": "^1.4.0",
+        "yaml-eslint-parser": "^2.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.38.0"
+      }
+    },
+    "node_modules/eslint-plugin-yml/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5219,63 +5267,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nconf": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.1.tgz",
-      "integrity": "sha512-p2cfF+B3XXacQdswUYWZ0w6Vld0832A/tuqjLBu3H1sfUcby4N2oVbGhyuCkZv+t3iY3aiFEj7gZGqax9Q2c1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async": "^3.0.0",
-        "ini": "^2.0.0",
-        "secure-keys": "^1.0.0",
-        "yargs": "^16.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/nconf/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/nconf/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/nconf/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/negotiator": {
       "version": "0.6.4",
@@ -8345,13 +8336,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/secure-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
-      "integrity": "sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/semantic-release": {
       "version": "25.0.2",
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.2.tgz",
@@ -10063,20 +10047,50 @@
         "node": ">=10"
       }
     },
-    "node_modules/yaml-lint": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/yaml-lint/-/yaml-lint-1.7.0.tgz",
-      "integrity": "sha512-zeBC/kskKQo4zuoGQ+IYjw6C9a/YILr2SXoEZA9jM0COrSwvwVbfTiFegT8qYBSBgOwLMWGL8sY137tOmFXGnQ==",
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yaml-eslint-parser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-2.0.0.tgz",
+      "integrity": "sha512-h0uDm97wvT2bokfwwTmY6kJ1hp6YDFL0nRHwNKz8s/VD1FH/vvZjAKoMUE+un0eaYBSG7/c6h+lJTP+31tjgTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "consola": "^2.15.3",
-        "globby": "^11.1.0",
-        "js-yaml": "^4.1.0",
-        "nconf": "^0.12.0"
+        "eslint-visitor-keys": "^5.0.0",
+        "yaml": "^2.0.0"
       },
-      "bin": {
-        "yamllint": "dist/cli.js"
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      }
+    },
+    "node_modules/yaml-eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "pretest": "npm run lint",
     "print-env": "print-env",
     "lint": "eslint --fix",
-    "lint:yaml": "yamllint '*.yml' '.buildkite/*.yml' '.circleci/*.yml' '.github/workflows/*.yml' '.semaphore/*.yml' 'basic/**/*.yml' ",
     "e2e": "cypress run",
     "e2e:chrome": "cypress run --browser chrome",
     "e2e:edge": "cypress run --browser edge",
@@ -71,12 +70,12 @@
     "eslint": "10.0.0",
     "eslint-plugin-cypress": "5.3.0",
     "eslint-plugin-mocha": "11.2.0",
+    "eslint-plugin-yml": "3.3.1",
     "globals": "17.3.0",
     "globby": "11.1.0",
     "husky": "9.0.6",
     "semantic-release": "25.0.2",
-    "start-server-and-test": "2.0.11",
-    "yaml-lint": "1.7.0"
+    "start-server-and-test": "2.0.11"
   },
   "engines": {
     "node": "^20.0.0 || ^22.0.0 || >=24.0.0"


### PR DESCRIPTION
## Situation

- Yaml files are linted with the npm module [yaml-lint](https://www.npmjs.com/package/yaml-lint). This was last published 4 years ago and it has a dependency on the legacy version [11.1.0](https://www.npmjs.com/package/globby/v/11.1.0) of the npm package [globby](https://www.npmjs.com/package/globby)
- The [eslint-plugin-yml](https://www.npmjs.com/package/eslint-plugin-yml) offers a modern alternative, aligned with ESLint that is already used for other linting targets. See also documentation https://ota-meshi.github.io/eslint-plugin-yml/

## Change

- Remove [yaml-lint](https://www.npmjs.com/package/yaml-lint) and references to it
- Add [eslint-plugin-yml](https://www.npmjs.com/package/eslint-plugin-yml) to [eslint.config.mjs](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/eslint.config.mjs)
- Use `yml/recommended` as base set of rules
- Add rule language: `yml/yaml` for consistent indentation and apply the rule to existing yaml files

## Verification

```shell
npm ci
npx eslint
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily lint/tooling changes plus YAML reformatting; the main risk is accidental CI/buildspec behavior change if indentation edits were incorrect.
> 
> **Overview**
> Switches YAML linting from the unmaintained `yaml-lint` script to ESLint via `eslint-plugin-yml`, adding a dedicated `**/*.yml` config (`yml/recommended` + indentation/spacing rules) and updating dependencies/lockfile accordingly.
> 
> Removes the `lint:yaml` script and pre-commit hook invocation, and reindents CI YAML files (GitHub Actions workflow and AWS CodeBuild `buildspec` variants) to satisfy the new YAML lint rules without changing intended commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ebde8ba52656e19cb22ecd253f07eec28988b9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->