### PR TITLE
chore: group cypress docker image updates with Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,11 @@
     {
       "matchPackageNames": ["/eslint/", "globals"],
       "groupName": "eslint"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "groupName": "cypress-docker-images",
+      "matchPackageNames": ["/^cypress/.*/"]
     }
   ]
 }


### PR DESCRIPTION
## Situation

The [renovate.json](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/renovate.json) currently handles updates for the Cypress Docker images `cypress/base:<node-version>` & `cypress/browsers:<node-version>` separately and only for Cypress Docker images used in CircleCI configs. These two images should use identical Node.js versions.

## Change

In [renovate.json](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/renovate.json) create a new group `cypress-docker-images` to update both types of images in one PR for CircleCI configs.

## Note

This only handles updates for Cypress Docker images used in CircleCI configs. These are the only places where the Docker images are used in live examples.

Documentation-only examples, such as [gitlab-ci.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.gitlab-ci.yml), need to be updated manually from time to time. Leaving the documentation-only examples on slightly older versions does not invalidate the examples. Users copying these examples can update them to whichever Node.js version they need.

## Reference

https://docs.renovatebot.com/docker/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts Renovate grouping rules for Docker image dependency updates; no runtime code changes.
> 
> **Overview**
> Renovate config now groups all `cypress/*` Docker image updates (datasource `docker`) into a single `cypress-docker-images` PR group, instead of raising separate PRs per image.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fe968d215585b4eb2105595deebc3b195bdcd1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->