### PR TITLE
chore(deps): update start-server-and-test to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-plugin-yml": "3.3.1",
         "globals": "17.4.0",
         "husky": "9.1.7",
-        "start-server-and-test": "2.1.5"
+        "start-server-and-test": "3.0.0"
       },
       "engines": {
         "node": "^22.14.0 || >=24.11.0"
@@ -835,23 +835,26 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -1672,13 +1675,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2057,22 +2053,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-stream": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
-      }
-    },
     "node_modules/eventemitter2": {
       "version": "6.4.7",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
@@ -2325,13 +2305,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "9.1.0",
@@ -2988,9 +2961,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3069,12 +3042,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/map-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
-      "dev": true
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -3420,19 +3387,6 @@
       "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
       "license": "MIT"
     },
-    "node_modules/pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
-      "dev": true,
-      "license": [
-        "MIT",
-        "Apache2"
-      ],
-      "dependencies": {
-        "through": "~2.3"
-      }
-    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -3520,22 +3474,6 @@
       "integrity": "sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ps-tree": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
-      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "event-stream": "=3.3.4"
-      },
-      "bin": {
-        "ps-tree": "bin/ps-tree.js"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -3985,19 +3923,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "through": "2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/sshpk": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
@@ -4025,9 +3950,9 @@
       }
     },
     "node_modules/start-server-and-test": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-2.1.5.tgz",
-      "integrity": "sha512-A/SbXpgXE25ScSkpLLqvGvVZT0ykN6+AzS8tVqMBCTxbJy2Nwuen59opT+afalK5aS+AuQmZs0EsLwjnuDN+/g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-3.0.0.tgz",
+      "integrity": "sha512-R//IdnWC+H+raB6zJIqw5QbIsMAjjYFwJC/OIJO6kgZljguYe4n4LlA7vkPTO7zoctFlVPfymsNShjcPOIH8nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4037,7 +3962,7 @@
         "debug": "4.4.3",
         "execa": "5.1.1",
         "lazy-ass": "1.6.0",
-        "ps-tree": "1.2.0",
+        "tree-kill": "1.2.2",
         "wait-on": "9.0.4"
       },
       "bin": {
@@ -4046,7 +3971,7 @@
         "start-test": "src/bin/start.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": "^22 || >=24"
       }
     },
     "node_modules/start-server-and-test/node_modules/execa": {
@@ -4094,16 +4019,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "duplexer": "~0.1.1"
       }
     },
     "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-yml": "3.3.1",
     "globals": "17.4.0",
     "husky": "9.1.7",
-    "start-server-and-test": "2.1.5"
+    "start-server-and-test": "3.0.0"
   },
   "engines": {
     "node": "^22.14.0 || >=24.11.0"


### PR DESCRIPTION
## Situation

- `npm audit` / Dependabot reports a critical vulnerability in `axios`, a transient dependency of `start-server-and-test`
- Renovate is disabled from automatically creating PRs (see https://github.com/cypress-io/cypress-example-kitchensink/issues/1085), which would otherwise fix the issue semi-automatically

## Change

- Update to [start-server-and-test@3.0.0](https://github.com/bahmutov/start-server-and-test/releases/tag/v3.0.0) (does not fix the vulnerability, is however a good housekeeping step)
- Execute `npm audit fix` (also fixes a high severity vulnerability in `lodash`)

## Alternative

A maintainer could initiate the updates via Renovate, see https://developer.mend.io/github/cypress-io/cypress-example-kitchensink - Pending Approval

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a dev-dependency/lockfile update affecting local/CI test orchestration; functional app code is unchanged, but CI scripts that rely on `start-test` could behave slightly differently after the major version bump.
> 
> **Overview**
> **Updates test tooling dependencies.** Bumps `start-server-and-test` from `2.1.5` to `3.0.0` in `package.json` and `package-lock.json`.
> 
> **Refreshes transitive deps via lockfile changes.** This upgrades `axios` and `lodash`, replaces `ps-tree` with `tree-kill`, and removes several older stream-related packages (e.g., `event-stream`, `duplexer`, `split`) from the dependency graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1ccc45238715095a8cdb43bc667eb0c3a8161e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->