### PR TITLE
chore(renovate): restrict cypress/base & /browsers to <25

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,8 @@
     {
       "matchDatasources": ["docker"],
       "groupName": "cypress-docker-images",
-      "matchPackageNames": ["/^cypress/.*/"]
+      "matchPackageNames": ["cypress/base", "cypress/browsers"],
+      "allowedVersions": "<25"
     }
   ]
 }


### PR DESCRIPTION
## Situation

`cypress/base` and `cypress/browsers` Docker images in this repo are intended to be used with the Node.js Active LTS version. This is currently Node.js 24.x.

A rejected Renovate PR at the moment blocks automatic updates to the Docker images using Node.js 25. If Cypress.io however publishes either of these Docker images based on Node.js 26, when this is released later in April 2026, then Renovate will propose to update to this version.

Node.js 26 is planned to move to Active LTS status on 2026-10-28.

## Change

Modify the [renovate.json](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/renovate.json) configuration to restrict the Cypress Docker images `cypress/base` and `cypress/browsers` to `<25`.

The match for `cypress/included` is dropped from the configuration, since it is not used in this repo, and it does not use a pure Node.js tag notation. Its short-tag is instead based on the Cypress version.

When Cypress.io first publishes Docker images based on a Node.js 26 Active LTS release, then this restriction can be bumped to <27.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Renovate dependency update rules, affecting which Cypress Docker image tags Renovate will propose.
> 
> **Overview**
> Updates `renovate.json` to narrow the Cypress Docker image rule to only `cypress/base` and `cypress/browsers`, and adds an `allowedVersions: "<25"` constraint so Renovate won’t propose Node 25+ based image tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b1477cc4a3fa9cd59eb9b92e6dd05507bd2f660. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->