### PR TITLE
fix: todo id generation

### DIFF
--- a/app/assets/js/todo/store.js
+++ b/app/assets/js/todo/store.js
@@ -9,6 +9,8 @@
 (function (window) {
   'use strict'
 
+  let ID = 1
+
   /**
    * Creates a new client side storage object and will create an empty
    * collection if no collection already exists.
@@ -100,7 +102,7 @@
       callback.call(this, todos)
     } else {
       // Generate an ID
-      updateData.id = new Date().getTime()
+      updateData.id = ID++
 
       todos.push(updateData)
       localStorage.setItem(this._dbName, JSON.stringify(todos))


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-example-kitchensink/issues/1104

## Situation

Selecting the generated "Walk the dog" item on the "todos" list as shown on https://example.cypress.io/todo does not lead to it being marked as completed.

The item IDs are generated using JavaScript millisecond timestamps and there is no mechanism in place to ensure that the IDs are unique.

## Change

Replace the ID generation that uses timestamps with one incrementing a number instead.

This solution is successfully used by the reference implementation on https://github.com/tastejs/todomvc/blob/master/examples/javascript-es5/src/store.js

This is a minimal change to fix the issue.

The test [cypress/e2e/1-getting-started/todo.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/1-getting-started/todo.cy.js) could be enhanced in a follow-on PR, so that it detects the issue of selecting an auto-generated item that is not the first one in the list, and then failing, when it is not marked as completed.

## Verification

Ubuntu 24.04.4 LTS, Node.js 24.15.0

Execute:

```shell
npm ci
npm start
```

In a separate terminal, execute:

```shell
npx cypress run -s cypress/e2e/1-getting-started/todo.cy.js
```

Test also manually:

Browse to http://localhost:8080/todo in Google Chrome
Click on site data to left of address
Select "Cookies and site data"
Select "Manage on-device site data"
Click on trash icon for `localhost`
Click on Reload

Select "Play electric bill"
Select "Walk the dog"

Both items should be shown checked and with strike-through text
Click "Clear completed"
Confirm both items deleted

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client-side todo ID generation, which can affect selection/update/remove behavior and may introduce collisions with existing persisted todos if the counter resets on reload.
> 
> **Overview**
> Fixes todo item creation to generate IDs via a module-level incrementing counter (`ID++`) instead of `new Date().getTime()`, preventing duplicate IDs when multiple items are added within the same millisecond.
> 
> This is a minimal change isolated to `app/assets/js/todo/store.js` and affects only newly-created todos (update paths remain unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d73ba25590c2ce831dddbe1d69b132f2ad54985. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->