### PR TITLE
fix: update .scrollIntoView() example for Cypress 16 visibility default

### DIFF
--- a/cypress/e2e/2-advanced-examples/actions.cy.js
+++ b/cypress/e2e/2-advanced-examples/actions.cy.js
@@ -235,28 +235,42 @@ context('Actions', () => {
   it('.scrollIntoView() - scroll an element into view', () => {
     // https://on.cypress.io/scrollintoview
 
-    // normally all of these buttons are hidden,
-    // because they're not within
-    // the viewable area of their parent
-    // (we need to scroll to see them)
-    cy.get('#scroll-horizontal button')
-      .should('not.be.visible')
+    // normally all of these buttons are positioned outside
+    // their scroll container's viewable area
+    // (we need to scroll to see them).
+    //
+    // As of Cypress 16, the default visibility algorithm uses the
+    // browser's Element.checkVisibility() API, which does not treat
+    // scroll-clipped elements as hidden. Assert that the button sits
+    // outside the scroll container's visible bounds before scrolling,
+    // then verify it becomes visible after scrolling.
+    cy.get('#scroll-horizontal button').then(($el) => {
+      const container = $el[0].closest('#scroll-horizontal')
+      expect($el[0].getBoundingClientRect().left).to.be.greaterThan(container.getBoundingClientRect().right)
+    })
 
     // scroll the button into view, as if the user had scrolled
     cy.get('#scroll-horizontal button').scrollIntoView()
     cy.get('#scroll-horizontal button')
       .should('be.visible')
 
-    cy.get('#scroll-vertical button')
-      .should('not.be.visible')
+    cy.get('#scroll-vertical button').then(($el) => {
+      const container = $el[0].closest('#scroll-vertical')
+      expect($el[0].getBoundingClientRect().top).to.be.greaterThan(container.getBoundingClientRect().bottom)
+    })
 
     // Cypress handles the scroll direction needed
     cy.get('#scroll-vertical button').scrollIntoView()
     cy.get('#scroll-vertical button')
       .should('be.visible')
 
-    cy.get('#scroll-both button')
-      .should('not.be.visible')
+    cy.get('#scroll-both button').then(($el) => {
+      const container = $el[0].closest('#scroll-both')
+      const elRect = $el[0].getBoundingClientRect()
+      const containerRect = container.getBoundingClientRect()
+      expect(elRect.left).to.be.greaterThan(containerRect.right)
+      expect(elRect.top).to.be.greaterThan(containerRect.bottom)
+    })
 
     // Cypress knows to scroll to the right and down
     cy.get('#scroll-both button').scrollIntoView()

--- a/cypress/e2e/2-advanced-examples/actions.cy.js
+++ b/cypress/e2e/2-advanced-examples/actions.cy.js
@@ -235,15 +235,10 @@ context('Actions', () => {
   it('.scrollIntoView() - scroll an element into view', () => {
     // https://on.cypress.io/scrollintoview
 
-    // normally all of these buttons are positioned outside
-    // their scroll container's viewable area
-    // (we need to scroll to see them).
-    //
-    // As of Cypress 16, the default visibility algorithm uses the
-    // browser's Element.checkVisibility() API, which does not treat
-    // scroll-clipped elements as hidden. Assert that the button sits
-    // outside the scroll container's visible bounds before scrolling,
-    // then verify it becomes visible after scrolling.
+    // normally all of these buttons are hidden,
+    // because they're not within
+    // the viewable area of their parent
+    // (we need to scroll to see them)
     cy.get('#scroll-horizontal button').then(($el) => {
       const container = $el[0].closest('#scroll-horizontal')
       expect($el[0].getBoundingClientRect().left).to.be.greaterThan(container.getBoundingClientRect().right)


### PR DESCRIPTION
- Closes <!-- No issue -->

### Additional details

Cypress 16 changes the default visibility algorithm to use the browser's native `Element.checkVisibility()` API, which intentionally does not treat scroll-clipped elements as hidden. The `.scrollIntoView() - scroll an element into view` example in `cypress/e2e/2-advanced-examples/actions.cy.js` was asserting `should('not.be.visible')` on three buttons positioned outside their scroll container's visible bounds (`#scroll-horizontal`, `#scroll-vertical`, `#scroll-both`). Those assertions pass under the legacy ancestor-walking algorithm but fail under the new default.

This change replaces the `should('not.be.visible')` checks with geometric assertions via `getBoundingClientRect()` that verify the same underlying condition (the button sits outside the scroll container's visible area), so the example continues to demonstrate `scrollIntoView()` correctly under both the legacy and modern visibility algorithms.

Companion to https://github.com/cypress-io/cypress/pull/33794.

### Steps to test

1. Pull this branch and run `cypress run --spec cypress/e2e/2-advanced-examples/actions.cy.js` with a 16.x build of Cypress (the default `visibilityStrategy: 'modern'`).
2. Verify the `.scrollIntoView() - scroll an element into view` test passes.
3. Optionally rerun with `visibilityStrategy: 'legacy'` set in `cypress.config.js` — the test should still pass (the geometric assertion is algorithm-agnostic).

### How has the user experience changed?

End users see no visible runtime change. The example test file's commands and expected behavior are unchanged; only the intermediate assertion is updated to remain correct under Cypress 16's new default visibility algorithm.

### PR Tasks

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [\`cypress-documentation\`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [\`type definitions\`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates Cypress example test assertions to avoid relying on the legacy visibility algorithm; no production code paths are touched.
> 
> **Overview**
> Updates the `.scrollIntoView()` example in `actions.cy.js` to stop asserting `should('not.be.visible')` for scroll-clipped elements (which no longer holds under Cypress 16’s modern visibility strategy).
> 
> Replaces those checks with geometry-based assertions using `getBoundingClientRect()` against the scroll container bounds, while keeping the post-`scrollIntoView()` `should('be.visible')` expectations unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e4e37e24c8c273ac03d33da5d480922a6bd3d73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->