### PR TITLE
fix: make getAllCookies example order-independent for Firefox

### DIFF
--- a/app/commands/cookies.html
+++ b/app/commands/cookies.html
@@ -132,22 +132,27 @@ cy.getCookies().should('have.length', 1).should((cookies) => {
 cy.setCookie('key', 'value')
 cy.setCookie('key', 'value', { domain: 'example.com' })
 
-// cy.getAllCookies() yields an array of cookies
+// cy.getAllCookies() yields an array of cookies (order is not guaranteed)
 cy.getAllCookies().should('have.length', 2).should((cookies) => {
-  // each cookie has these properties
-  expect(cookies[0]).to.have.property('name', 'key')
-  expect(cookies[0]).to.have.property('value', 'value')
-  expect(cookies[0]).to.have.property('httpOnly', false)
-  expect(cookies[0]).to.have.property('secure', false)
-  expect(cookies[0]).to.have.property('domain')
-  expect(cookies[0]).to.have.property('path')
+  const hostCookie = cookies.find((cookie) => cookie.domain !== '.example.com')
+  const exampleCookie = cookies.find((cookie) => cookie.domain === '.example.com')
 
-  expect(cookies[1]).to.have.property('name', 'key')
-  expect(cookies[1]).to.have.property('value', 'value')
-  expect(cookies[1]).to.have.property('httpOnly', false)
-  expect(cookies[1]).to.have.property('secure', false)
-  expect(cookies[1]).to.have.property('domain', 'example.com')
-  expect(cookies[1]).to.have.property('path')
+  // each cookie has these properties
+  expect(hostCookie).to.exist
+  expect(hostCookie).to.have.property('name', 'key')
+  expect(hostCookie).to.have.property('value', 'value')
+  expect(hostCookie).to.have.property('httpOnly', false)
+  expect(hostCookie).to.have.property('secure', false)
+  expect(hostCookie).to.have.property('domain')
+  expect(hostCookie).to.have.property('path')
+
+  expect(exampleCookie).to.exist
+  expect(exampleCookie).to.have.property('name', 'key')
+  expect(exampleCookie).to.have.property('value', 'value')
+  expect(exampleCookie).to.have.property('httpOnly', false)
+  expect(exampleCookie).to.have.property('secure', false)
+  expect(exampleCookie).to.have.property('domain', '.example.com')
+  expect(exampleCookie).to.have.property('path')
 })</code></pre>
         </div>
         <div class="col-xs-5">

--- a/cypress/e2e/2-advanced-examples/cookies.cy.js
+++ b/cypress/e2e/2-advanced-examples/cookies.cy.js
@@ -44,22 +44,27 @@ context('Cookies', () => {
     cy.setCookie('key', 'value')
     cy.setCookie('key', 'value', { domain: '.example.com' })
 
-    // cy.getAllCookies() yields an array of cookies
+    // cy.getAllCookies() yields an array of cookies (order is not guaranteed)
     cy.getAllCookies().should('have.length', 2).should((cookies) => {
-      // each cookie has these properties
-      expect(cookies[0]).to.have.property('name', 'key')
-      expect(cookies[0]).to.have.property('value', 'value')
-      expect(cookies[0]).to.have.property('httpOnly', false)
-      expect(cookies[0]).to.have.property('secure', false)
-      expect(cookies[0]).to.have.property('domain')
-      expect(cookies[0]).to.have.property('path')
+      const hostCookie = cookies.find((cookie) => cookie.domain !== '.example.com')
+      const exampleCookie = cookies.find((cookie) => cookie.domain === '.example.com')
 
-      expect(cookies[1]).to.have.property('name', 'key')
-      expect(cookies[1]).to.have.property('value', 'value')
-      expect(cookies[1]).to.have.property('httpOnly', false)
-      expect(cookies[1]).to.have.property('secure', false)
-      expect(cookies[1]).to.have.property('domain', '.example.com')
-      expect(cookies[1]).to.have.property('path')
+      // each cookie has these properties
+      expect(hostCookie).to.exist
+      expect(hostCookie).to.have.property('name', 'key')
+      expect(hostCookie).to.have.property('value', 'value')
+      expect(hostCookie).to.have.property('httpOnly', false)
+      expect(hostCookie).to.have.property('secure', false)
+      expect(hostCookie).to.have.property('domain')
+      expect(hostCookie).to.have.property('path')
+
+      expect(exampleCookie).to.exist
+      expect(exampleCookie).to.have.property('name', 'key')
+      expect(exampleCookie).to.have.property('value', 'value')
+      expect(exampleCookie).to.have.property('httpOnly', false)
+      expect(exampleCookie).to.have.property('secure', false)
+      expect(exampleCookie).to.have.property('domain', '.example.com')
+      expect(exampleCookie).to.have.property('path')
     })
   })
 


### PR DESCRIPTION
## Summary

- Updates the scaffolded `cy.getAllCookies()` example in `cookies.cy.js` to assert cookies by domain instead of array index
- Fixes failures in Firefox 151 where `getAllCookies()` returns cookies in a different order than other browsers (cypress-io/cypress#33843)
- Closes #1121

## Test plan

- [ ] `npx cypress run --browser firefox --spec cypress/e2e/2-advanced-examples/cookies.cy.js`
- [ ] `npx cypress run --browser chrome --spec cypress/e2e/2-advanced-examples/cookies.cy.js`


Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only example documentation and a scaffolded E2E spec to avoid relying on cookie array ordering, with no production logic changes.
> 
> **Overview**
> Makes the `cy.getAllCookies()` example and corresponding `cookies.cy.js` test **order-independent** by no longer asserting on `cookies[0]`/`cookies[1]`.
> 
> The updated assertions explicitly note that cookie order is not guaranteed and instead locate the host vs `.example.com` cookie via `Array.find()` before checking expected properties, improving cross-browser stability (notably Firefox).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d097707b19178b0e6b25bd8cf9c01d355e2b7832. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->