### PR TITLE
test

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-The MIT License (MIT)
+qweThe MIT License (MIT)
 
 Copyright (c) 2019 Cypress.io, Inc.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cosmetic documentation-only change with no runtime or security impact; the stray prefix may be unintended test noise.
> 
> **Overview**
> Prepends the literal text **`qwe`** to the first line of **`LICENSE`**, so the license header reads `qweThe MIT License (MIT)` instead of `The MIT License (MIT)`. No other lines in the file are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d290f1a4b91b363bf8cd2b633ef7185031b28c7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->