### PR TITLE
chore(deps): add cypress to allowScripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,5 +77,8 @@
   },
   "engines": {
     "node": "^22.14.0 || >=24.11.0"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-example-kitchensink/issues/1147

## Situation

Running `npm ci` under the current Node.js 24 LTS version, in alignment with the [.node-version](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.node-version) setting, results in a warning:

```console
npm warn allow-scripts 1 package has install scripts not yet covered by allowScripts:
npm warn allow-scripts   cypress@15.19.0 (postinstall: node dist/index.js --exec install)
npm warn allow-scripts
npm warn allow-scripts Run `npm approve-scripts --allow-scripts-pending` to review, or `npm approve-scripts <pkg>` to allow.
```

The warnings also show in https://github.com/cypress-io/cypress-example-kitchensink/actions/workflows/single.yml?query=branch%3Amaster, for example.

## Change

Execute

```shell
npm ci --ignore-scripts
npm approve-scripts cypress --no-allow-scripts-pin
npm rebuild
```

to add an `allowScripts` key to `package.json` in order to silence the warning from `npm@11.16.0`.

## Verification

Execute the following on Ubuntu 24.04.4 LTS with Node.js 24.18.0 and confirm there is no `allow-scripts` warning:

```shell
git clean -xfd
npm ci
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only `package.json` metadata change; no runtime, auth, or application logic is affected.
> 
> **Overview**
> Adds an **`allowScripts`** block to **`package.json`** so **`cypress`** is explicitly allowed to run its **`postinstall`** script under **npm 11** on Node 24 LTS.
> 
> This removes the **`allow-scripts`** warning during **`npm ci`** without changing dependencies or install behavior beyond npm’s script-approval policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13b5e9fa935ae4c2568bad0d9bf2dfed87f2a8a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->