### PR TITLE
fix(test): remove obsolete cy.exec Windows skips

### DIFF
--- a/cypress/e2e/2-advanced-examples/misc.cy.js
+++ b/cypress/e2e/2-advanced-examples/misc.cy.js
@@ -16,27 +16,6 @@ context('Misc', () => {
     // https://on.cypress/io/platform
     cy.log(`Platform ${Cypress.platform} architecture ${Cypress.arch}`)
 
-    // on CircleCI Windows build machines we have a failure to run bash shell
-    // https://github.com/cypress-io/cypress/issues/5169
-    // so skip some of the tests by passing flag "--expose circle=true"
-    const isCircleOnWindows = Cypress.platform === 'win32' && Cypress.expose('circle')
-
-    if (isCircleOnWindows) {
-      cy.log('Skipping test on CircleCI')
-
-      return
-    }
-
-    // cy.exec problem on Shippable CI
-    // https://github.com/cypress-io/cypress/issues/6718
-    const isShippable = Cypress.platform === 'linux' && Cypress.expose('shippable')
-
-    if (isShippable) {
-      cy.log('Skipping test on ShippableCI')
-
-      return
-    }
-
     cy.exec('echo Jane Lane')
       .its('stdout').should('contain', 'Jane Lane')
 


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-example-kitchensink/issues/1159
- closes https://github.com/cypress-io/cypress-example-kitchensink/issues/1160

## Situation

The [cypress/e2e/2-advanced-examples/misc.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/2-advanced-examples/misc.cy.js) test spec skips testing `cy.exec()` in CI providers on Windows:

- Shippable
- CircleCI

In general, the `cy.exec()` compatibility issues on Windows were resolved in [cypress@15.0.0](https://docs.cypress.io/app/references/changelog#15-0-0). The underlying [execa](https://www.npmjs.com/package/execa) package was updated from `1.0.0` to [4.1.0](https://github.com/sindresorhus/execa/releases?page=3#release-v4.1.0).

For Shippable, in addition, the CI provider is no longer operating and the domain https://shippable.com/ is no longer reachable.

## Change

- Remove the corresponding `cy.exec()` skips from [cypress/e2e/2-advanced-examples/misc.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/2-advanced-examples/misc.cy.js) which previously avoided the execution of `cy.exec()` using the above CI providers.

## Verification

### Local

On Ubuntu 24.04.4 LTS, Node.js 24.18.0, execute:

```shell
git clone https://github.com/cypress-io/cypress-example-kitchensink
cd cypress-example-kitchensink
npm ci
npm run test:ci
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in an example spec; no production or security impact, with possible CI noise if legacy environments still fail on `cy.exec`.
> 
> **Overview**
> Removes **early-return skips** in the `cy.exec()` example spec that used to bail out on CircleCI Windows (`Cypress.expose('circle')`) and Shippable Linux (`Cypress.expose('shippable')`), so those `cy.exec` assertions always run in CI again.
> 
> The rest of the test (platform logging, `echo`, and `print`/`cat` config file checks) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e098fd1a8e029e98cbab9e4c1378fce873d71c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->