### PR TITLE
ci: pin third-party action SHAs and use lockfile cache keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,14 +34,14 @@ jobs:
             nvm install 24.18.0
             nvm use 24.18.0
       - restore_cache:
-          key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+          key: dependencies-v1-{{ arch }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
 
       - run: npm ci
       - run: npm run cy:verify
       - run: npm run cy:info
 
       - save_cache:
-          key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+          key: dependencies-v1-{{ arch }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:
             # could not use environment variables for some reason
             - C:\Users\circleci\AppData\Local\Cypress\Cache
@@ -74,17 +74,20 @@ jobs:
             nvm install 24.18.0
             nvm use 24.18.0
       - restore_cache:
-          key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+          key: dependencies-v1-{{ arch }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
 
       # install Chrome browser on Windows machine using Chocolatey
       # https://chocolatey.org/packages/GoogleChrome
+      # The package downloads from a floating URL that Google updates in place, so its
+      # published checksum goes stale on each Chrome release. There is no stable hash to
+      # pin, which is why verification is skipped rather than fixed.
       - run: choco install googlechrome --ignore-checksums -y
       - run: npm ci
       - run: npm run cy:verify
       - run: npm run cy:info
 
       - save_cache:
-          key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+          key: dependencies-v1-{{ arch }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:
             # could not use environment variables for some reason
             - C:\Users\circleci\AppData\Local\Cypress\Cache
@@ -117,7 +120,7 @@ jobs:
             nvm install 24.18.0
             nvm use 24.18.0
       - restore_cache:
-          key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+          key: dependencies-v1-{{ arch }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
 
       # install Firefox browser on Windows machine using Chocolatey
       # https://chocolatey.org/packages/Firefox
@@ -127,7 +130,7 @@ jobs:
       - run: npm run cy:info
 
       - save_cache:
-          key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+          key: dependencies-v1-{{ arch }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:
             # could not use environment variables for some reason
             - C:\Users\circleci\AppData\Local\Cypress\Cache

--- a/.github/workflows/chrome-docker.yml
+++ b/.github/workflows/chrome-docker.yml
@@ -10,9 +10,9 @@ jobs:
     container: cypress/browsers:24.18.0
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Chrome
-        uses: cypress-io/github-action@v7
+        uses: cypress-io/github-action@fa4a118725a8f001170d49631ea89e5d66fee626 # v7.4.1
         timeout-minutes: 10
         with:
           build: npm run build

--- a/.github/workflows/chrome.yml
+++ b/.github/workflows/chrome.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
       - name: Chrome
-        uses: cypress-io/github-action@v7
+        uses: cypress-io/github-action@fa4a118725a8f001170d49631ea89e5d66fee626 # v7.4.1
         timeout-minutes: 10
         with:
           build: npm run build

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -13,19 +13,19 @@ jobs:
     name: Install npm and Cypress
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # install a specific version of Node using
       # https://github.com/actions/setup-node
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
 
       # just so we learn about available environment variables GitHub provides
       - name: Print CI env variables
         run: |
-          npm i -g @bahmutov/print-env@2
+          npm i -g @bahmutov/print-env@2.1.2
           print-env GITHUB BUILD ACTIONS || true
 
       # Restore the previous npm modules and Cypress binary archives.
@@ -35,7 +35,7 @@ jobs:
       # we use exact restore key to avoid npm module snowballing
       # https://glebbahmutov.com/blog/do-not-let-npm-cache-snowball/
       - name: Cache central npm modules
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
@@ -45,7 +45,7 @@ jobs:
       # we use the exact restore key to avoid Cypress binary snowballing
       # https://glebbahmutov.com/blog/do-not-let-cypress-cache-snowball/
       - name: Cache Cypress binary
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
@@ -54,7 +54,7 @@ jobs:
 
       # Cache local node_modules to pass to testing jobs
       - name: Cache local node_modules
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
@@ -79,18 +79,18 @@ jobs:
     runs-on: ubuntu-24.04
     needs: install
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # install a specific version of Node using
       # https://github.com/actions/setup-node
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
 
       # Restore just local node_modules and the Cypress binary archives.
       - name: Cache Cypress binary
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
@@ -98,7 +98,7 @@ jobs:
             cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Cache local node_modules
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
@@ -124,7 +124,7 @@ jobs:
 
       # Save screenshots as test artifacts
       # https://github.com/actions/upload-artifact
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         # there might be no screenshots created when:
         # - there are no test failures
         # so only upload screenshots if previous step has failed
@@ -138,18 +138,18 @@ jobs:
     runs-on: ubuntu-24.04
     needs: install
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # install a specific version of Node using
       # https://github.com/actions/setup-node
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
 
       # Restore just local node_modules and the Cypress binary archives.
       - name: Cache Cypress binary
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
@@ -157,7 +157,7 @@ jobs:
             cypress-${{ runner.os }}-cypress-${{ github.ref }}-
 
       - name: Cache local node_modules
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
@@ -183,7 +183,7 @@ jobs:
 
       # Save screenshots as test artifacts
       # https://github.com/actions/upload-artifact
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         # there might be no screenshots created when:
         # - there are no test failures
         # so only upload screenshots if previous step has failed

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -12,7 +12,7 @@ jobs:
     name: Lint Title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -9,19 +9,19 @@ jobs:
     name: Cypress test
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # install a specific version of Node using
       # https://github.com/actions/setup-node
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
 
       # just so we learn about available environment variables GitHub provides
       - name: Print env variables
         run: |
-          npm i -g @bahmutov/print-env
+          npm i -g @bahmutov/print-env@2.1.2
           print-env GITHUB
 
       # Restore the previous npm modules and Cypress binary archives.
@@ -29,13 +29,13 @@ jobs:
       # and saved automatically after the entire workflow successfully finishes.
       # See https://github.com/actions/cache
       - name: Cache node modules
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - name: Cache Cypress binary
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package-lock.json') }}
@@ -66,7 +66,7 @@ jobs:
 
       # Save screenshots as test artifacts
       # https://github.com/actions/upload-artifact
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         # there might be no screenshots created when:
         # - there are no test failures
         # so only upload screenshots if previous step has failed

--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
       - name: Cypress run
-        uses: cypress-io/github-action@v7
+        uses: cypress-io/github-action@fa4a118725a8f001170d49631ea89e5d66fee626 # v7.4.1
         timeout-minutes: 10
         with:
           build: npm run build
@@ -41,15 +41,15 @@ jobs:
         containers: [1, 2, 3, 4]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@v7
+        uses: cypress-io/github-action@fa4a118725a8f001170d49631ea89e5d66fee626 # v7.4.1
         timeout-minutes: 5
         with:
           record: true
@@ -76,15 +76,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
       # because of "record" and "parallel" parameters
       # these containers will load balance all found tests among themselves
       - name: run tests
-        uses: cypress-io/github-action@v7
+        uses: cypress-io/github-action@fa4a118725a8f001170d49631ea89e5d66fee626 # v7.4.1
         timeout-minutes: 10
         with:
           record: true


### PR DESCRIPTION
## Summary

CI hardening for this repo's GitHub Actions workflows and CircleCI config, from an internal review of our CI configuration. Three changes, all low-risk; see **Not included** below for what was deliberately left out and why.

### 1. Pin all third-party GitHub Actions to commit SHAs

Every action in this repo was on a mutable major tag. Pinned all six to commit SHAs with a trailing version comment:

| Action | Pinned to |
| --- | --- |
| `actions/checkout` | `3d3c42e5` (v7.0.1) |
| `actions/setup-node` | `82076278` (v7.0.0) |
| `actions/cache` | `55cc8345` (v6.1.0) |
| `actions/upload-artifact` | `043fb46d` (v7.0.1) |
| `cypress-io/github-action` | `fa4a1187` (v7.4.1) |
| `amannn/action-semantic-pull-request` | `48f25628` (v6.1.1) |

**Every SHA is the commit the floating tag already resolved to**, so this is behaviorally a no-op today — it only removes the ability for a retag to change what runs.

This matters most for `amannn/action-semantic-pull-request`, the one third-party (non-`actions/`, non-Cypress) action here. It runs on `pull_request_target`, so it executes in the base-repo context on every fork PR, and because this repo's default workflow permissions are `write` it receives a write-scoped `GITHUB_TOKEN`.

Worth noting `cypress-io/github-action@v7` was resolving through a **branch** ref (`refs/heads/v7`), not a tag — a branch head is more freely mutable than a tag.

Renovate manages this format natively and will bump both the SHA and the comment, so the pins won't silently rot.

### 2. CircleCI Windows cache keys use the lockfile

```diff
-key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+key: dependencies-v1-{{ arch }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
```

`package.json` carries declared ranges; `package-lock.json` carries the resolved tree. Keying on the manifest meant two different installed dependency trees could share one cache entry. The `v1-` prefix makes the keys deliberately invalidatable.

Note this invalidates the existing Windows caches once, so the three `win-test*` jobs run cold on this PR.

### 3. Pin `@bahmutov/print-env`

`single.yml` installed it entirely unpinned and `parallel.yml` used a `@2` major range. Both now pin `@2.1.2` — the version already pinned in `devDependencies`. These are demonstration-only steps, and in `single.yml` the install lands in the same job that later holds `CYPRESS_RECORD_KEY`.

## Not included

**`--ignore-checksums` on the Windows Chrome install** — left in place deliberately, with the comment corrected. The original comment said "until a fix can be found" (added in #735, Sept 2023); the honest answer is that no fix exists at that layer:

- The Chocolatey `googlechrome` package downloads from a **floating URL** that Google updates in place, while baking a static checksum at packaging time. Its own README documents the resulting mismatch window. There is no correct hash to pin, so the checksum is a liveness check against Chocolatey and Google being out of sync, not an integrity control.
- This is live right now — chocolatey-community/chocolatey-packages#2808 is open as of 2026-07-20 against the exact package version CI would install. Removing the flag would likely just break the job.
- The step can't be dropped either: Chrome is not preinstalled on `windows-server-2022-gui`, and `circleci/browser-tools` has never supported Windows (its `install_chrome` script is Linux/macOS only).

Contrast `win-test-firefox`, which needs no such flag because Mozilla uses version-pinned, permanently-archived URLs. This is a vendor distribution difference, not something fixable here.

If we do want the flag gone, the real option is replacing Chocolatey with a direct `msiexec` install of the enterprise MSI — same security posture, but it removes the moderation-lag failure mode. That needs its own PR and a Windows CI run to validate, so I kept it out of a hardening change.

**Required status checks on `master`** — a repository setting rather than code, so it can't ship in a PR. Being handled separately.

**The two `@develop` reusable-workflow refs and their `secrets: inherit`** — left for a separate change.

## How has the user experience changed?

No user-facing change. This repo's workflows double as copy-paste examples, so the one visible difference is that `uses:` lines now carry SHAs plus a version comment instead of a bare major tag. That's noisier to read but is GitHub's documented hardening guidance, and it matches the pattern already used in `cypress-io/cypress`'s own workflows.

## PR Tasks

- [x] Have tests been added/updated? `N/A` — CI configuration only.
- [x] Has the original issue or PR been linked? #735 for the `--ignore-checksums` history.
- [x] Have API changes been merged? `N/A`
- [x] Has a PR for user-facing changes been opened in `cypress-documentation`? `N/A`
- [x] Have new configuration options been added to `cypress.schema.json`? `N/A`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only configuration with no application or runtime changes; SHA pins match what tags already resolved to, aside from intentional cache key invalidation on Windows.
> 
> **Overview**
> **CI hardening** across GitHub Actions and CircleCI: third-party actions are pinned to **commit SHAs** (with version comments) instead of floating major tags, so workflow behavior cannot change from a retag—especially relevant for `pull_request_target` semantic PR linting.
> 
> CircleCI **Windows** `restore_cache` / `save_cache` keys now use **`package-lock.json`** checksums and a **`dependencies-v1-`** prefix (replacing `package.json`), so caches match the resolved dependency tree; expect a one-time cold cache on those jobs.
> 
> Workflow demo steps that install **`@bahmutov/print-env`** are pinned to **`@2.1.2`**. The Windows Chrome Chocolatey step keeps **`--ignore-checksums`**; the comment is updated to explain why checksum verification cannot be relied on for that package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7759d0ae3a964eccd506f7e3bc85d2e2ad4d2db3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->