### PR TITLE
chore(deps): update ci examples to Node.js 24.18.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,8 @@ jobs:
           name: Install Node.js
           command: |
             nvm --version
-            nvm install 24.13.0
-            nvm use 24.13.0
+            nvm install 24.18.0
+            nvm use 24.18.0
       - restore_cache:
           key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
 
@@ -71,8 +71,8 @@ jobs:
           name: Install Node.js
           command: |
             nvm --version
-            nvm install 24.13.0
-            nvm use 24.13.0
+            nvm install 24.18.0
+            nvm use 24.18.0
       - restore_cache:
           key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
 
@@ -114,8 +114,8 @@ jobs:
           name: Install Node.js
           command: |
             nvm --version
-            nvm install 24.13.0
-            nvm use 24.13.0
+            nvm install 24.18.0
+            nvm use 24.18.0
       - restore_cache:
           key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
 
@@ -151,9 +151,9 @@ jobs:
       - run:
           name: Install Node.js
           command: |
-            nvm install 24.13.0
-            nvm use 24.13.0
-            nvm alias default 24.13.0
+            nvm install 24.18.0
+            nvm use 24.18.0
+            nvm alias default 24.18.0
       - cypress/install:
           post-install: "npm run build"
       # show Cypress cache folder and binary versions
@@ -172,7 +172,7 @@ jobs:
     parallelism: 3
     executor:
       name: cypress/default
-      node-version: '24.13.0'
+      node-version: '24.18.0'
     steps:
       - cypress/install:
           post-install: 'npm run build'
@@ -194,7 +194,7 @@ jobs:
     parallelism: 2
     executor:
       name: cypress/default
-      node-version: '24.13.0'
+      node-version: '24.18.0'
     steps:
       - browser-tools/install_chrome
       - cypress/install
@@ -207,7 +207,7 @@ jobs:
     parallelism: 2
     executor:
       name: cypress/default
-      node-version: '24.13.0'
+      node-version: '24.18.0'
     steps:
       - browser-tools/install_firefox
       - cypress/install
@@ -218,7 +218,7 @@ jobs:
   release:
     executor:
       name: cypress/default
-      node-version: '24.13.0'
+      node-version: '24.18.0'
     steps:
       - checkout
       - run: npm ci

--- a/.github/workflows/chrome-docker.yml
+++ b/.github/workflows/chrome-docker.yml
@@ -7,7 +7,7 @@ jobs:
   chrome:
     runs-on: ubuntu-24.04
     # https://github.com/cypress-io/cypress-docker-images
-    container: cypress/browsers:24.17.0
+    container: cypress/browsers:24.18.0
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
   agent {
     // this image provides everything needed to run Cypress
     docker {
-      image 'cypress/base:24.13.0'
+      image 'cypress/base:24.18.0'
     }
   }
 

--- a/basic/Jenkinsfile
+++ b/basic/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
   agent {
     // this image provides everything needed to run Cypress
     docker {
-      image 'cypress/base:24.13.0'
+      image 'cypress/base:24.18.0'
     }
   }
 

--- a/buddy.yml
+++ b/buddy.yml
@@ -8,7 +8,7 @@
       type: "BUILD"
       working_directory: "/buddy/cypress-example-kitchensink"
       docker_image_name: "cypress/base"
-      docker_image_tag: "24.13.0"
+      docker_image_tag: "24.18.0"
       execute_commands:
         - "npm install --force"
         - "npm run cy:verify"


### PR DESCRIPTION
## Situation

Example workflows currently use a mixture of Node.js versions

- 24
- 24.13.0
- 24.17.0
- 24.18.0

including use of `cypress/base` & `cypress/browser` Docker images tagged with a Node.js version. The mixture is due to Renovate automated updates and manual updates.

## Change

- Update example CI workflows / pipelines to use Node.js `24.18.0` (or leave as-is using `24`, or `24.x` - depending on the CI provider)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only version pin updates with no application or runtime code changes.
> 
> **Overview**
> Aligns example CI/CD configs on **Node.js 24.18.0** so the kitchensink no longer mixes patch levels (`24.13.0`, `24.17.0`, etc.).
> 
> **CircleCI** Windows jobs switch `nvm install`/`use` from `24.13.0` to `24.18.0`; Mac sets the same via `nvm alias default`. Linux Cypress orb jobs and the **release** job update `node-version` from `24.13.0` to `24.18.0`.
> 
> **GitHub Actions** Chrome Docker workflow uses `cypress/browsers:24.18.0` instead of `24.17.0`. **Jenkins** (root and `basic/`) and **Buddy** move `cypress/base` from `24.13.0` to `24.18.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 500e4507f326f270c5d312a949fef894ee65f25d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->