### PR TITLE
chore(deps): update eslint-plugin-mocha to 12.0.2

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,6 +25,7 @@ export default defineConfig([
       '@stylistic/quotes': ['error', 'single'],
       '@stylistic/semi': ['error', 'never'],
       '@stylistic/space-before-function-paren': ['error', 'always'],
+      'mocha/no-async-in-sync-tests': 'off', // must be off for Cypress compatibility
       'mocha/no-exclusive-tests': 'error',
       'mocha/no-pending-tests': 'error',
       'mocha/no-mocha-arrows': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "cypress": "15.19.0",
         "eslint": "10.7.0",
         "eslint-plugin-cypress": "6.4.3",
-        "eslint-plugin-mocha": "11.3.0",
+        "eslint-plugin-mocha": "12.0.2",
         "eslint-plugin-yml": "3.6.0",
         "globals": "17.7.0",
         "husky": "9.1.7",
@@ -29,6 +29,16 @@
       },
       "engines": {
         "node": "^22.14.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@bahmutov/print-env": {
@@ -99,9 +109,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1815,27 +1825,50 @@
       }
     },
     "node_modules/eslint-plugin-mocha": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-11.3.0.tgz",
-      "integrity": "sha512-anENwrIwmdvunmmssjMn5a4nTd+mYMkqBlwjksxOECcIThLNhefWJIiTWY7pY/arMQFjNwHQjVOZb6pQ9PrLjg==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-12.0.2.tgz",
+      "integrity": "sha512-RzjnzVBoidGFjVcvzQShLbfWug5pL/6d6LZFbBZk1b5duZ0ooq6dasmpu6qLyNowUZBqaWvQbnR5U1hsKX/+5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.1",
-        "globals": "^15.14.0"
+        "@eslint-community/eslint-utils": "4.10.1",
+        "@eslint/core": "1.2.1",
+        "@types/estree": "1.0.9",
+        "globals": "17.8.0",
+        "json-schema-to-ts": "3.1.1",
+        "type-fest": "5.8.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "eslint": ">=9.0.0"
+        "eslint": ">=10.2.0"
       }
     },
     "node_modules/eslint-plugin-mocha/node_modules/globals": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "version": "17.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
+      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-mocha/node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2758,6 +2791,20 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -4105,6 +4152,19 @@
         "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/throttleit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.1.tgz",
@@ -4167,6 +4227,13 @@
       "bin": {
         "tree-kill": "cli.js"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "cypress": "15.19.0",
     "eslint": "10.7.0",
     "eslint-plugin-cypress": "6.4.3",
-    "eslint-plugin-mocha": "11.3.0",
+    "eslint-plugin-mocha": "12.0.2",
     "eslint-plugin-yml": "3.6.0",
     "globals": "17.7.0",
     "husky": "9.1.7",


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-example-kitchensink/issues/1174
- supersedes https://github.com/cypress-io/cypress-example-kitchensink/pull/1173

## Situation

- Renovate PR https://github.com/cypress-io/cypress-example-kitchensink/pull/1173 attempted to update to [eslint-plugin-mocha@12.0.0](https://github.com/lo1tuma/eslint-plugin-mocha/releases#release-eslint-plugin-mocha@12.0.0) |

This fails linting because the `recommended` config was changed to enable the rule [no-async-in-sync-tests](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-async-in-sync-tests.md) which is incompatible with regular Cypress tests.

## Change

Update
| FROM                                                                                                 | TO                                                                                                                       |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
| [eslint-plugin-mocha@11.3.0](https://github.com/lo1tuma/eslint-plugin-mocha/releases#release-11.3.0) | [eslint-plugin-mocha@12.0.2](https://github.com/lo1tuma/eslint-plugin-mocha/releases#release-eslint-plugin-mocha@12.0.2) |

Disable [mocha/no-async-in-sync-tests](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-async-in-sync-tests.md) which otherwise flags errors in correct Cypress tests.

## Verification

```shell
npm ci
npm run lint
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only lint dependency bump and a targeted rule override; no runtime or application behavior changes.
> 
> **Overview**
> Bumps **eslint-plugin-mocha** from `11.3.0` to `12.0.2` (with lockfile updates for its new transitive deps).
> 
> v12’s recommended config turns on **`mocha/no-async-in-sync-tests`**, which breaks lint on valid Cypress specs. This PR explicitly sets **`mocha/no-async-in-sync-tests`: `off`** in `eslint.config.mjs`, with a comment that it’s required for Cypress compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1314a5f0880426cb50a169cd1c0cba9062386228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->