### PR TITLE
chore(deps): update cypress to 16.0.0

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,5 +1,4 @@
 module.exports = {
   projectId: '4b7344',
-  allowCypressEnv: false,
   e2e: {},
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@eslint/json": "2.0.1",
         "@html-eslint/eslint-plugin": "0.64.0",
         "@stylistic/eslint-plugin": "5.10.0",
-        "cypress": "15.21.1",
+        "cypress": "16.0.0",
         "eslint": "10.8.1",
         "eslint-plugin-cypress": "7.0.1",
         "eslint-plugin-mocha": "12.0.2",
@@ -978,16 +978,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer": {
@@ -1483,9 +1483,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.21.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.21.1.tgz",
-      "integrity": "sha512-ogHpHMj0XNlZA5MGzjg8SWHf0eMw9lTwVQRKjpcT1GzNTxNUjwnHA8YCG6nOJ8ThU+XZaUxJgpMYZnJ//8aDaw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-16.0.0.tgz",
+      "integrity": "sha512-/H3zsayGwIGboFIiLWaXxy6ADmCdWy5QjjDBZgslCvjIgYAf1DkZerwAM7wXMPSpfpQ4w+lGjFlmwneRBpg27g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1506,7 +1506,7 @@
         "cli-table3": "0.6.1",
         "commander": "^6.2.1",
         "common-tags": "^1.8.0",
-        "dayjs": "^1.10.4",
+        "dayjs": "^1.11.23",
         "debug": "^4.3.4",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
@@ -1534,7 +1534,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^20.1.0 || ^22.0.0 || >=24.0.0"
+        "node": "^22.0.0 || ^24.0.0 || >=26.0.0"
       }
     },
     "node_modules/cypress/node_modules/arch": {
@@ -1598,9 +1598,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.21",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
-      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "version": "1.11.23",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2183,9 +2183,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -3754,9 +3754,9 @@
       "license": "MIT"
     },
     "node_modules/serve-handler/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3861,9 +3861,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@eslint/json": "2.0.1",
     "@html-eslint/eslint-plugin": "0.64.0",
     "@stylistic/eslint-plugin": "5.10.0",
-    "cypress": "15.21.1",
+    "cypress": "16.0.0",
     "eslint": "10.8.1",
     "eslint-plugin-cypress": "7.0.1",
     "eslint-plugin-mocha": "12.0.2",


### PR DESCRIPTION
## Situation

[cypress@16.0.0](https://docs.cypress.io/app/references/changelog#16-0-0) was released on Sep 1, 2026.

The `allowCypressEnv` [configuration](https://docs.cypress.io/app/references/configuration) option is removed.

## Change

Update to [cypress@16.0.0](https://docs.cypress.io/app/references/changelog#16-0-0).

Remove `allowCypressEnv` from [cypress.config.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress.config.js).

Run `npm audit fix`

## Verification

```shell
npm ci
npm run test:ci:chrome
npm audit
```

Expect and confirm:

```console
All specs passed!
found 0 vulnerabilities
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-dependency and test-runner upgrade with a single config cleanup; no application or security-critical runtime code changes.
> 
> **Overview**
> Upgrades **Cypress** from `15.21.1` to **`16.0.0`** in `package.json` and refreshes `package-lock.json` (including Cypress’s stricter Node engine range and minor transitive bumps such as `dayjs`).
> 
> Removes the **`allowCypressEnv`** setting from `cypress.config.js` because Cypress 16 dropped that configuration option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3c5ed4007b932da72c8f0fa9ff0f5a3f446192e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->