### PR TITLE
ci: migrate GitHub Actions using-action CI to cypress/browsers

### DIFF
--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -1,4 +1,4 @@
-name: Using Cypress GH Action
+name: Using Cypress GitHub Action
 
 on: [push, workflow_dispatch]
 
@@ -7,7 +7,7 @@ jobs:
     name: Single (non-recording)
     # This job can run in the parent repository, or in a fork, because it does
     # not record to Cypress Cloud, and so it does not need a projectId with Record Key.
-    # It runs all tests in a single container, and does not use
+    # It runs all tests in a single job, and does not use
     # Cypress Cloud load balancing.
     runs-on: ubuntu-24.04
     steps:
@@ -32,19 +32,24 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       # when one test fails, DO NOT cancel the other
-      # containers, because this will kill Cypress processes
+      # jobs, because this will kill Cypress processes
       # leaving the Cypress Cloud dashboard hanging ...
       # https://github.com/cypress-io/github-action/issues/48
       fail-fast: false
       matrix:
         # Run 4 copies of the current job in parallel.
-        # The name of the array (containers) and
+        # The name of the array (recording-job) and
         # the actual items in the array (1, 2, 3, 4) do not matter.
         # Based on the array, GitHub Actions will create
         # 4 independently running parallel jobs
-        # (see https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs).
+        # (see https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/run-job-variations).
         # Cypress Cloud load-balances the Cypress tests across the GitHub Actions jobs.
-        containers: [1, 2, 3, 4]
+        recording-job: [1, 2, 3, 4]
+    # Use a Cypress Docker image with browsers pre-installed
+    # to ensure that the tests run in the same consistent environment across each parallel run
+    container:
+      image: cypress/browsers:24.20.0
+      options: --user 1001
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -53,7 +58,7 @@ jobs:
         with:
           node-version-file: .node-version
       # because of "record" and "parallel" parameters
-      # these containers will load balance all found tests among themselves
+      # these jobs will load balance all found tests among themselves
       - name: run tests
         uses: cypress-io/github-action@09090944bd8aaa2a517cefb6e38bf1aae336b42b # v7.4.3
         timeout-minutes: 5
@@ -63,46 +68,5 @@ jobs:
           group: GH Action parallel
           start: npm start
         env:
-          # pass the Dashboard record key as an environment variable
-          CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}
-
-  parallel-runs-across-platforms:
-    name: Every OS
-    # Only run this job in the parent repository, not in any fork.
-    # To use the example in a fork, a different projectId and Record Key are required.
-    if: github.repository_owner == 'cypress-io'
-    strategy:
-      # when one test fails, DO NOT cancel the other
-      # containers, because this will kill Cypress processes
-      # leaving the Cypress Cloud dashboard hanging ...
-      # https://github.com/cypress-io/github-action/issues/48
-      fail-fast: false
-      matrix:
-        # run 2 copies of the current job in parallel
-        # and they will load balance all specs
-        os: ['ubuntu-24.04', 'windows-latest', 'macos-latest']
-        containers: [1, 2]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version-file: .node-version
-      # because of "record" and "parallel" parameters
-      # these containers will load balance all found tests among themselves
-      - name: run tests
-        uses: cypress-io/github-action@09090944bd8aaa2a517cefb6e38bf1aae336b42b # v7.4.3
-        timeout-minutes: 10
-        with:
-          record: true
-          parallel: true
-          group: Parallel 2x on ${{ matrix.os }}
-          # on Mac and Linux we can use "npm start"
-          start: npm start
-          # but for this particular project on Windows we need a different start command
-          start-windows: npm run start
-        env:
-          # pass the Cypress Cloud (dashboard) record key as an environment variable
+          # pass the Cypress Cloud record key as an environment variable
           CYPRESS_RECORD_KEY: ${{ secrets.dashboardRecordKey }}


### PR DESCRIPTION
- contributes to resolving issue https://github.com/cypress-io/cypress-example-kitchensink/issues/1197

## Situation

The GitHub Actions workflow [.github/workflows/using-action.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/using-action.yml) records into Cypress Cloud, running in parallel and using the default browser, which is currently Electron.

The workflow demonstrates using the JavaScript GitHub Action [cypress-io/github-action](https://github.com/cypress-io/github-action#readme).

- The `parallel-runs` job uses `ubuntu-24.04`
- The `parallel-runs-across-platforms` uses a matrix of
  - `ubuntu-24.04`
  - `windows-latest`
  - `macos-latest`

Electron is deprecated (see https://github.com/cypress-io/cypress-example-kitchensink/issues/1196) which means that the browser needs to be supplied by a Cypress Docker image, since the native GitHub Actions runner images are not able to guarantee a consistent environment across parallel jobs during deployment of new runner images.

Cypress Docker images can only be used with Ubuntu.

## Change

- Remove the `parallel-runs-across-platforms` job, since it is only viable for Ubuntu, and it would then duplicate `parallel-runs`.
- Use the `cypress/browsers` Docker image to provide browsers for the `parallel-runs` recording job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes; less cross-OS coverage in examples but no application or security impact.
> 
> **Overview**
> Updates the **Using Cypress GitHub Action** workflow so recorded parallel runs use a pinned **`cypress/browsers:24.20.0`** job container (with `--user 1001`) instead of relying on the default runner/Electron setup, giving a consistent browser environment across the four matrix jobs.
> 
> The **`parallel-runs-across-platforms`** job (Ubuntu/Windows/macOS matrix) is **removed**, leaving **`parallel-runs`** as the only Cloud recording example. Comments and matrix naming are adjusted (`containers` → **`recording-job`**, “containers” → “jobs” in docs links/text); the non-recording **`single-run`** job is unchanged aside from wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f2bc0d5c31c26d79a25c0edbf440c77ce27f305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->