### PR TITLE
ci: migrate GitHub Actions parallel CI to cypress/browsers

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -8,6 +8,11 @@ name: Cypress parallel tests
 
 on: [push, workflow_dispatch]
 
+env:
+  # override the Cypress Docker image cache location
+  # which is normally /root/.cache/Cypress
+  CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cache/Cypress
+
 jobs:
   install:
     name: Install npm and Cypress
@@ -15,6 +20,7 @@ jobs:
     # To use the example in a fork, a different projectId and Record Key are required.
     if: github.repository_owner == 'cypress-io'
     runs-on: ubuntu-24.04
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -50,7 +56,7 @@ jobs:
       - name: Cache Cypress binary
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/.cache/Cypress
+          path: .cache/Cypress
           key: cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
@@ -81,6 +87,11 @@ jobs:
     name: Cypress test 1
     runs-on: ubuntu-24.04
     needs: install
+    # Use a Cypress Docker image with browsers pre-installed
+    # to ensure that the tests run in the same consistent environment across each parallel run
+    container:
+      image: cypress/browsers:24.20.0
+      options: --user 1001
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -95,7 +106,7 @@ jobs:
       - name: Cache Cypress binary
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/.cache/Cypress
+          path: .cache/Cypress
           key: cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
@@ -140,6 +151,11 @@ jobs:
     name: Cypress test 2
     runs-on: ubuntu-24.04
     needs: install
+    # Use a Cypress Docker image with browsers pre-installed
+    # to ensure that the tests run in the same consistent environment across each parallel run
+    container:
+      image: cypress/browsers:24.20.0
+      options: --user 1001
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -154,7 +170,7 @@ jobs:
       - name: Cache Cypress binary
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/.cache/Cypress
+          path: .cache/Cypress
           key: cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             cypress-${{ runner.os }}-cypress-${{ github.ref }}-


### PR DESCRIPTION
- contributes to resolving issue https://github.com/cypress-io/cypress-example-kitchensink/issues/1197

## Situation

The GitHub Actions workflow [.github/workflows/parallel.yml](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/parallel.yml) records into Cypress Cloud, running in parallel and using the default browser, which is currently Electron.

The workflow uses CLI commands to run Cypress in two parallel running jobs:

- `test1`
- `test2`

Electron is deprecated (see https://github.com/cypress-io/cypress-example-kitchensink/issues/1196) which means that the browser needs to be supplied by a Cypress Docker image, since the native GitHub Actions runner images are not able to guarantee a consistent environment across parallel jobs during deployment of new runner images.

## Change

- Use the `cypress/browsers` Docker image to provide browsers for the two recording jobs `test1` & `test2`.
- Adjust `CYPRESS_CACHE_FOLDER` to override Cypress Docker image default `/root/.cache/Cypress` using GitHub Workspace instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes; no application or runtime code is affected, though parallel Cypress recording could fail if container or cache paths are misconfigured.
> 
> **Overview**
> Updates the **Cypress parallel tests** workflow so the two recording jobs (`test1`, `test2`) run inside **`cypress/browsers:24.20.0`** with `--user 1001`, instead of relying on the default runner/Electron setup. That pins a consistent browser stack across parallel shards as runner images roll out.
> 
> Workflow-wide **`CYPRESS_CACHE_FOLDER`** is set to `${{ github.workspace }}/.cache/Cypress`, and all Cypress binary cache steps now use **`.cache/Cypress`** instead of `~/.cache/Cypress`, so the install job and container jobs share the same cached binary path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8e4904490ebc78b574efbb19c09836c811fe8b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->